### PR TITLE
Add blur operation

### DIFF
--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1734,6 +1734,17 @@ def test_gaussian_blur(fx_asset, display):
         assert 0.655 <= after.blue < 0.67
 
 
+def test_blur(fx_asset, display):
+    with Image(filename=str(fx_asset.join('sasha.jpg'))) as img:
+        before = img[100, 100]
+        img.blur(30, 10)
+        after = img[100, 100]
+        assert before != after
+        assert 0.84 <= after.red <= 0.851
+        assert 0.74 <= after.green <= 0.75
+        assert 0.655 <= after.blue < 0.67
+
+
 def test_modulate(fx_asset, display):
     with Image(filename=str(fx_asset.join('sasha.jpg'))) as img:
         before = img[100, 100]

--- a/wand/api.py
+++ b/wand/api.py
@@ -624,6 +624,10 @@ try:
                                                 ctypes.c_double,
                                                 ctypes.c_double]
 
+    library.MagickBlurImage.argtypes = [ctypes.c_void_p,
+                                        ctypes.c_double,
+                                        ctypes.c_double]
+
     library.MagickUnsharpMaskImage.argtypes = [ctypes.c_void_p,
                                                ctypes.c_double,
                                                ctypes.c_double,

--- a/wand/image.py
+++ b/wand/image.py
@@ -2408,6 +2408,33 @@ class BaseImage(Resource):
             self.raise_exception()
 
     @manipulative
+    def blur(self, radius, sigma):
+        """Blurs the image.  We convolve the image with a gaussian operator
+        of the given ``radius`` and standard deviation (``sigma``).
+        For reasonable results, the ``radius`` should be larger
+        than ``sigma``.  Use a ``radius`` of 0 and :meth:`blur()` selects
+        a suitable ``radius`` for you.
+
+        :param radius: the radius of the, in pixels,
+                       not counting the center pixel
+        :type radius: :class:`numbers.Real`
+        :param sigma: the standard deviation of the, in pixels
+        :type sigma: :class:`numbers.Real`
+
+        .. versionadded:: 0.4.5
+
+        """
+        if not isinstance(radius, numbers.Real):
+            raise TypeError('radius has to be a numbers.Real, not ' +
+                            repr(radius))
+        elif not isinstance(sigma, numbers.Real):
+            raise TypeError('sigma has to be a numbers.Real, not ' +
+                            repr(sigma))
+        r = library.MagickBlurImage(self.wand, radius, sigma)
+        if not r:
+            self.raise_exception()
+
+    @manipulative
     def unsharp_mask(self, radius, sigma, amount, threshold):
         """Sharpens the image using unsharp mask filter. We convolve the image
         with a Gaussian operator of the given ``radius`` and standard deviation


### PR DESCRIPTION
This is also Gaussian blur, but much much faster.
Explanation: http://www.imagemagick.org/Usage/blur/#blur_gaussian

``` python
In [1]: from wand.image import Image
In [2]: im = Image(filename='../_in.bmp')
In [3]: im.size
Out[3]: (480L, 480L)

In [4]: %time im2 = im.clone(); im2.blur(30, 10)
Wall time: 151 ms

In [5]: %time im2 = im.clone(); im2.gaussian_blur(30, 10)
Wall time: 4.29 s
```
