### PR TITLE
exhaustively search for libraries in magick_home before calling find_…

### DIFF
--- a/wand/api.py
+++ b/wand/api.py
@@ -83,10 +83,11 @@ def library_paths():
     combinations = itertools.product(versions, options)
     suffixes = (version + option for version, option in combinations)
     if magick_home:
-        # exhaustively search for libraries in magick_home before calling find_library
+        # exhaustively search for libraries in magick_home before calling
+        # find_library
         for suffix in suffixes:
-            # On Windows, the API is split between two libs. On other platforms,
-            # it's all contained in one.
+            # On Windows, the API is split between two libs.
+            # On other platforms, it's all contained in one.
             if system == 'Windows':
                 libwand = 'CORE_RL_wand_{0}.dll'.format(suffix),
                 libmagick = 'CORE_RL_magick_{0}.dll'.format(suffix),

--- a/wand/api.py
+++ b/wand/api.py
@@ -81,10 +81,12 @@ def library_paths():
     def magick_path(path):
         return os.path.join(magick_home, *path)
     combinations = itertools.product(versions, options)
-    for suffix in (version + option for version, option in combinations):
-        # On Windows, the API is split between two libs. On other platforms,
-        # it's all contained in one.
-        if magick_home:
+    suffixes = (version + option for version, option in combinations)
+    if magick_home:
+        # exhaustively search for libraries in magick_home before calling find_library
+        for suffix in suffixes:
+            # On Windows, the API is split between two libs. On other platforms,
+            # it's all contained in one.
             if system == 'Windows':
                 libwand = 'CORE_RL_wand_{0}.dll'.format(suffix),
                 libmagick = 'CORE_RL_magick_{0}.dll'.format(suffix),
@@ -98,6 +100,7 @@ def library_paths():
             else:
                 libwand = 'lib', 'libMagickWand{0}.so'.format(suffix),
                 yield magick_path(libwand), magick_path(libwand)
+    for suffix in suffixes:
         if system == 'Windows':
             libwand = ctypes.util.find_library('CORE_RL_wand_' + suffix)
             libmagick = ctypes.util.find_library('CORE_RL_magick_' + suffix)

--- a/wand/version.py
+++ b/wand/version.py
@@ -223,6 +223,7 @@ def formats(pattern='*'):
         cursor += 1
     return formats
 
+
 if __doc__ is not None:
     __doc__ = __doc__.replace('0.0.0', VERSION)
 


### PR DESCRIPTION
…library. Previously this would only search for the first suffix (e.g. just `libMagickWand.so`) in `MAGICK_HOME` before resorting to `find_library` for the same suffix. For example, if `libMagickWand-6.Q16.so` was in `magick_home` but `libMagickWand.so` existed on the library path (e.g. if you compiled ImageMagick from source but had a different version already installed on your machine), it would not load the version of the library in `magick_home`. From what I could tell it didn't seem like there's a good way to write a test for this, but if there is I will add one.