### PR TITLE
Ensure image sequence was allocated before deallocation.

### DIFF
--- a/wand/api.py
+++ b/wand/api.py
@@ -83,10 +83,11 @@ def library_paths():
     combinations = itertools.product(versions, options)
     suffixes = (version + option for version, option in combinations)
     if magick_home:
-        # exhaustively search for libraries in magick_home before calling find_library
+        # exhaustively search for libraries in magick_home before calling
+        # find_library
         for suffix in suffixes:
-            # On Windows, the API is split between two libs. On other platforms,
-            # it's all contained in one.
+            # On Windows, the API is split between two libs.
+            # On other platforms, it's all contained in one.
             if system == 'Windows':
                 libwand = 'CORE_RL_wand_{0}.dll'.format(suffix),
                 libmagick = 'CORE_RL_magick_{0}.dll'.format(suffix),

--- a/wand/api.py
+++ b/wand/api.py
@@ -81,10 +81,12 @@ def library_paths():
     def magick_path(path):
         return os.path.join(magick_home, *path)
     combinations = itertools.product(versions, options)
-    for suffix in (version + option for version, option in combinations):
-        # On Windows, the API is split between two libs. On other platforms,
-        # it's all contained in one.
-        if magick_home:
+    suffixes = (version + option for version, option in combinations)
+    if magick_home:
+        # exhaustively search for libraries in magick_home before calling find_library
+        for suffix in suffixes:
+            # On Windows, the API is split between two libs. On other platforms,
+            # it's all contained in one.
             if system == 'Windows':
                 libwand = 'CORE_RL_wand_{0}.dll'.format(suffix),
                 libmagick = 'CORE_RL_magick_{0}.dll'.format(suffix),
@@ -98,6 +100,7 @@ def library_paths():
             else:
                 libwand = 'lib', 'libMagickWand{0}.so'.format(suffix),
                 yield magick_path(libwand), magick_path(libwand)
+    for suffix in suffixes:
         if system == 'Windows':
             libwand = ctypes.util.find_library('CORE_RL_wand_' + suffix)
             libmagick = ctypes.util.find_library('CORE_RL_magick_' + suffix)

--- a/wand/image.py
+++ b/wand/image.py
@@ -2764,8 +2764,9 @@ class Image(BaseImage):
         manager.
 
         """
-        for i in range(0, len(self.sequence)):
-            self.sequence.pop()
+        if self.sequence is not None:
+            for i in range(0, len(self.sequence)):
+                self.sequence.pop()
         super(Image, self).destroy()
 
     def read(self, file=None, filename=None, blob=None, resolution=None):

--- a/wand/version.py
+++ b/wand/version.py
@@ -223,6 +223,7 @@ def formats(pattern='*'):
         cursor += 1
     return formats
 
+
 if __doc__ is not None:
     __doc__ = __doc__.replace('0.0.0', VERSION)
 


### PR DESCRIPTION
Fixes issue #324, and probably a few others.

`wand.image.Image.sequence` is defined as `None` until the image resource is allocated, and qualifies of having multiple images/stack. Recent changes introduced `wand.image.Image.destroy` method; in which, it was assumed that `sequence` was always allocated.

This PR checks that `sequence` was allocated before attempting manual removal.