### PR TITLE
Fix exception when destroy corrupt image

### DIFF
--- a/wand/image.py
+++ b/wand/image.py
@@ -2764,8 +2764,9 @@ class Image(BaseImage):
         manager.
 
         """
-        for i in range(0, len(self.sequence)):
-            self.sequence.pop()
+        if self.sequence is not None:
+            for i in range(0, len(self.sequence)):
+                self.sequence.pop()
         super(Image, self).destroy()
 
     def read(self, file=None, filename=None, blob=None, resolution=None):


### PR DESCRIPTION
When open a corrupt image, the `image.destroy()` func will throw exception:

```
Exception ignored in: <bound method Resource.__del__ of <wand.image.Image: (empty)>>
Traceback (most recent call last):
  File "/Users/zippo/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/wand/resource.py", line 232, in __del__
    self.destroy()
  File "/Users/zippo/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/wand/image.py", line 2768, in destroy
    for i in range(0, len(self.sequence)):
TypeError: object of type 'NoneType' has no len()
```

This PR fix this ex.