### PR TITLE
WIN-PY27: Cast MAGICK_HOME to string

### DIFF
--- a/wand/api.py
+++ b/wand/api.py
@@ -70,7 +70,7 @@ def library_paths():
                 libPath = winreg.QueryValueEx(reg_key, "LibPath")
                 coderPath = winreg.QueryValueEx(reg_key, "CoderModulesPath")
                 filterPath = winreg.QueryValueEx(reg_key, "FilterModulesPath")
-                magick_home = libPath[0]
+                magick_home = str(libPath[0])
                 os.environ['PATH'] += (';' + libPath[0] + ";" +
                                        coderPath[0] + ";" + filterPath[0])
         except OSError:


### PR DESCRIPTION
Using Python 2.7.13 on Windows x64 the `winreg` module returns unicode strings. This results in something like:

```
Traceback (most recent call last):
  File "manage.py", line 20, in <module>
    init()
  File "C:\Users\fkraus\Projects\ams\ams\__init__.py", line 44, in init
    from ams.vendor import ObjectIDConverter
  File "C:\Users\fkraus\Projects\ams\ams\vendor\__init__.py", line 25, in <module>
    from ._py import AdvertisementStringIO
  File "C:\Users\fkraus\Projects\ams\ams\vendor\_py.py", line 5, in <module>
    from wand.image import Image
  File "C:\Users\fkraus\Envs\ams\lib\site-packages\wand\image.py", line 20, in <module>
    from .api import MagickPixelPacket, libc, libmagick, library
  File "C:\Users\fkraus\Envs\ams\lib\site-packages\wand\api.py", line 180, in <module>
    libraries = load_library()
  File "C:\Users\fkraus\Envs\ams\lib\site-packages\wand\api.py", line 126, in load_library
    libwand = ctypes.CDLL(libwand_path)
  File "C:\Python27\Lib\ctypes\__init__.py", line 362, in __init__
    self._handle = _dlopen(self._name, mode)
TypeError: LoadLibrary() argument 1 must be string, not unicode
```

Casting `magick_home` here to string solves the problem.