### PR TITLE
Fix TypeError when calling `destroy()` on an image

### DIFF
--- a/wand/image.py
+++ b/wand/image.py
@@ -2764,7 +2764,7 @@ class Image(BaseImage):
         manager.
 
         """
-        for i in range(0, len(self.sequence)):
+        while self.sequence:
             self.sequence.pop()
         super(Image, self).destroy()
 


### PR DESCRIPTION
`Image` objects with a `sequence` attribute of `None` would raise an error when `destroy()` was called on them.

This commit fixes the issue by only attempting to pop items from the sequence if the sequence is truthy.

Error for reference:
```
Exception ignored in: <bound method Resource.__del__ of <wand.image.Image: ddfad51 'CR2' (5202x3465)>>
Traceback (most recent call last):
  File "[redacted]/.venv/lib/python3.6/site-packages/wand/resource.py", line 232, in __del__
    self.destroy()
  File "[redacted]/.venv/lib/python3.6/site-packages/wand/image.py", line 2767, in destroy
    for i in range(0, len(self.sequence)):
TypeError: object of type 'NoneType' has no len()
```