### PR TITLE
Allow setting jpeg:size option

### DIFF
--- a/wand/api.py
+++ b/wand/api.py
@@ -421,6 +421,9 @@ try:
     library.MagickSampleImage.argtypes = [ctypes.c_void_p, ctypes.c_size_t,
                                           ctypes.c_size_t]
 
+    library.MagickSigmoidalContrastImage.argtypes = [ctypes.c_void_p, ctypes.c_bool,
+                                          ctypes.c_double, ctypes.c_double]
+
     library.MagickResizeImage.argtypes = [ctypes.c_void_p, ctypes.c_size_t,
                                           ctypes.c_size_t, ctypes.c_int,
                                           ctypes.c_double]

--- a/wand/image.py
+++ b/wand/image.py
@@ -1655,6 +1655,23 @@ class BaseImage(Resource):
             if not r:
                 self.raise_exception()
 
+    def sigmoidal_contrast(self, increase=True, strength=0.0, midpoint=0.0):
+        """Adjusts the contrast of an image with a non-linear
+        sigmoidal contrast algorithm using :c:func:`MagickSigmoidalContrastImage`
+
+        :param increase: increase or decrease contrast
+        :type increase: :class:`bool`
+        :param strength : how much to increase or decrease contrast
+                          (0 is none; 3 is typical; 20 is pushing it)
+        :type strength: :class:`numbers.Real`
+        :param midpoint: midpoint as a factor of quantum
+        :type midpoint: :class:`numbers.Real`
+
+        """
+
+        beta = float(self.quantum_range * midpoint)
+        library.MagickSigmoidalContrastImage(self.wand, increase, strength, beta)
+
     @manipulative
     def transform(self, crop='', resize=''):
         """Transforms the image using :c:func:`MagickTransformImage`,

--- a/wand/image.py
+++ b/wand/image.py
@@ -425,7 +425,7 @@ ORIENTATION_TYPES = ('undefined', 'top_left', 'top_right', 'bottom_right',
 #:
 #: .. versionchanged:: 0.3.9
 #:    Added ``'pdf:use-cropbox'`` option.
-OPTIONS = frozenset(['fill', 'jpeg:sampling-factor', 'pdf:use-cropbox'])
+OPTIONS = frozenset(['fill', 'jpeg:sampling-factor', 'pdf:use-cropbox', 'jpeg:size'])
 
 #: (:class:`tuple`) The list of :attr:`Image.compression` types.
 #:


### PR DESCRIPTION
Setting this JPEG decoder option can speed up JPEG resize operation dramatically, but it needs to be set prior to reading the JPEG:

```python
with Image() as img:
    img.options['jpeg:size'] = '300x300'
    img.read(filename='/path/to/file.jpg')
    ...
```