### PR TITLE
Potential fix for crashes on i686/i386

### DIFF
--- a/wand/cdefs/structures.py
+++ b/wand/cdefs/structures.py
@@ -4,7 +4,7 @@
 .. versionadded:: 0.5.0
 """
 from ctypes import POINTER, Structure, c_double, c_int, c_size_t
-from wand.cdefs.wandtypes import c_ssize_t
+from wand.cdefs.wandtypes import c_ssize_t, c_magick_real_t
 
 __all__ = ('AffineMatrix', 'KernelInfo', 'MagickPixelPacket', 'PixelInfo',
            'PointInfo')
@@ -55,11 +55,11 @@ class MagickPixelPacket(Structure):
                 ('matte', c_int),
                 ('fuzz', c_double),
                 ('depth', c_size_t),
-                ('red', c_double),
-                ('green', c_double),
-                ('blue', c_double),
-                ('opacity', c_double),
-                ('index', c_double)]
+                ('red', c_magick_real_t),
+                ('green', c_magick_real_t),
+                ('blue', c_magick_real_t),
+                ('opacity', c_magick_real_t),
+                ('index', c_magick_real_t)]
 
 
 class OffsetInfo(Structure):
@@ -76,12 +76,12 @@ class PixelInfo(Structure):
                 ('fuzz', c_double),
                 ('depth', c_size_t),
                 ('count', c_size_t),
-                ('red', c_double),
-                ('green', c_double),
-                ('blue', c_double),
-                ('black', c_double),
-                ('alpha', c_double),
-                ('index', c_double)]
+                ('red', c_magick_real_t),
+                ('green', c_magick_real_t),
+                ('blue', c_magick_real_t),
+                ('black', c_magick_real_t),
+                ('alpha', c_magick_real_t),
+                ('index', c_magick_real_t)]
 
 
 class PointInfo(Structure):

--- a/wand/cdefs/wandtypes.py
+++ b/wand/cdefs/wandtypes.py
@@ -4,8 +4,10 @@
 .. versionadded:: 0.5.0
 """
 import ctypes
+import os
+import sys
 
-__all__ = ('c_magick_char_p', 'c_ssize_t')
+__all__ = ('c_magick_char_p', 'c_magick_real_t', 'c_ssize_t')
 
 
 class c_magick_char_p(ctypes.c_char_p):
@@ -42,3 +44,17 @@ if not hasattr(ctypes, 'c_ssize_t'):
     elif ctypes.sizeof(ctypes.c_ulonglong) == ctypes.sizeof(ctypes.c_void_p):
         ctypes.c_ssize_t = ctypes.c_longlong
 c_ssize_t = ctypes.c_ssize_t
+
+
+env_real = os.getenv('WAND_REAL_TYPE', 'auto')
+if env_real in ('double', 'c_double'):
+    c_magick_real_t = ctypes.c_double
+elif env_real in ('longdouble', 'c_longdouble'):
+    c_magick_real_t = ctypes.c_longdouble
+else:
+    # Attempt to guess MagickRealType size
+    if sys.maxsize > 2**32:
+        c_magick_real_t = ctypes.c_double
+    else:
+        c_magick_real_t = ctypes.c_longdouble
+del env_real


### PR DESCRIPTION
This merge request attempts to fix issues #188, #247, and #335. If anyone connected to those issues, or has experienced segment-faults / coredumps, please help test this potential fix.

## Overview of bug.

This issue is isolated to 32bit architectures, and occurs with any `Color` deallocations in wand. It's caused by structure `MagickPixelPacket` having members defined as `MagickRealType`. The size of `MagickRealType` is defined at time of compile during the preprocessor stage, and the type is considered "private" and not exposed to the "public" MagickWand C-API.

_Blah, blah, blah -- What does this mean?_

If you're installing ImageMagick from a vendor/repo, you will not have visibility to `MagickRealType` size. This is fine as it's usually mapped to `ctypes.c_double`; however, on 32bit x86, it should be mapped to `ctypes.c_longdouble`.

## Help testing.

Folks running 32bit architecture can help test this by running `color_test.py` in an isolated virtual environment.

```sh
virtualenv i386_support && cd i386_support
source ./bin/activate
git clone https://github.com/emcconville/wand.git && cd wand
git checkout i386_support
pip install pytest memory_profiler==0.40
pip install -e .
pytest tests/color_test.py
```


