### PR TITLE
Move collections.abc to compat module

### DIFF
--- a/wand/compat.py
+++ b/wand/compat.py
@@ -6,17 +6,23 @@ multiple Python versions (2.6, 2.7, 3.3+) and VM implementations
 (CPython, PyPy).
 
 """
+import collections
 import contextlib
 import io
 import sys
 import types
 
-__all__ = ('PY3', 'binary', 'binary_type', 'encode_filename', 'file_types',
-           'nested', 'string_type', 'text', 'text_type', 'xrange')
+__all__ = ('PY3', 'abc', 'binary', 'binary_type', 'encode_filename',
+           'file_types', 'nested', 'string_type', 'text', 'text_type',
+           'xrange')
 
 
 #: (:class:`bool`) Whether it is Python 3.x or not.
 PY3 = sys.version_info >= (3,)
+
+#: (:class:`module`) Module containing abstract base classes.
+#: :mod:`collections` in Python 2 and :mod:`collections.abc` in Python 3.
+abc = collections.abc if PY3 else collections
 
 #: (:class:`type`) Type for representing binary data.  :class:`str` in Python 2
 #: and :class:`bytes` in Python 3.

--- a/wand/drawing.py
+++ b/wand/drawing.py
@@ -13,7 +13,7 @@ import numbers
 from .api import (AffineMatrix, MagickPixelPacket, PixelInfo, PointInfo,
                   library)
 from .color import Color
-from .compat import binary, string_type, text, text_type, xrange
+from .compat import abc, binary, string_type, text, text_type, xrange
 from .exceptions import WandLibraryVersionError
 from .image import BaseImage, COMPOSITE_OPERATORS
 from .sequence import SingleImage
@@ -27,7 +27,7 @@ __all__ = ('CLIP_PATH_UNITS', 'FILL_RULE_TYPES', 'FONT_METRICS_ATTRIBUTES',
            'TEXT_DIRECTION_TYPES', 'Drawing', 'FontMetrics')
 
 
-#: (:class:`collections.Sequence`) The list of clip path units
+#: (:class:`collections.abc.Sequence`) The list of clip path units
 #:
 #: - ``'undefined_path_units'``
 #: - ``'user_space'``
@@ -36,7 +36,7 @@ __all__ = ('CLIP_PATH_UNITS', 'FILL_RULE_TYPES', 'FONT_METRICS_ATTRIBUTES',
 CLIP_PATH_UNITS = ('undefined_path_units', 'user_space', 'user_space_on_use',
                    'object_bounding_box')
 
-#: (:class:`collections.Sequence`) The list of text align types.
+#: (:class:`collections.abc.Sequence`) The list of text align types.
 #:
 #: - ``'undefined'``
 #: - ``'left'``
@@ -44,7 +44,7 @@ CLIP_PATH_UNITS = ('undefined_path_units', 'user_space', 'user_space_on_use',
 #: - ``'right'``
 TEXT_ALIGN_TYPES = 'undefined', 'left', 'center', 'right'
 
-#: (:class:`collections.Sequence`) The list of text decoration types.
+#: (:class:`collections.abc.Sequence`) The list of text decoration types.
 #:
 #: - ``'undefined'``
 #: - ``'no'``
@@ -54,14 +54,14 @@ TEXT_ALIGN_TYPES = 'undefined', 'left', 'center', 'right'
 TEXT_DECORATION_TYPES = ('undefined', 'no', 'underline', 'overline',
                          'line_through')
 
-#: (:class:`collections.Sequence`) The list of text direction types.
+#: (:class:`collections.abc.Sequence`) The list of text direction types.
 #:
 #: - ``'undefined'``
 #: - ``'right_to_left'``
 #: - ``'left_to_right'``
 TEXT_DIRECTION_TYPES = ('undefined', 'right_to_left', 'left_to_right')
 
-#: (:class:`collections.Sequence`) The list of text gravity types.
+#: (:class:`collections.abc.Sequence`) The list of text gravity types.
 #:
 #: - ``'forget'``
 #: - ``'north_west'``
@@ -78,14 +78,14 @@ GRAVITY_TYPES = ('forget', 'north_west', 'north', 'north_east', 'west',
                  'center', 'east', 'south_west', 'south', 'south_east',
                  'static')
 
-#: (:class:`collections.Sequence`) The list of fill-rule types.
+#: (:class:`collections.abc.Sequence`) The list of fill-rule types.
 #:
 #: - ``'undefined'``
 #: - ``'evenodd'``
 #: - ``'nonzero'``
 FILL_RULE_TYPES = ('undefined', 'evenodd', 'nonzero')
 
-#: (:class:`collections.Sequence`) The attribute names of font metrics.
+#: (:class:`collections.abc.Sequence`) The attribute names of font metrics.
 FONT_METRICS_ATTRIBUTES = ('character_width', 'character_height', 'ascender',
                            'descender', 'text_width', 'text_height',
                            'maximum_horizontal_advance', 'x1', 'y1', 'x2',
@@ -94,7 +94,7 @@ FONT_METRICS_ATTRIBUTES = ('character_width', 'character_height', 'ascender',
 #: The tuple subtype which consists of font metrics data.
 FontMetrics = collections.namedtuple('FontMetrics', FONT_METRICS_ATTRIBUTES)
 
-#: (:class:`collections.Sequence`) The list of stretch types for fonts
+#: (:class:`collections.abc.Sequence`) The list of stretch types for fonts
 #:
 #: - ``'undefined;``
 #: - ``'normal'``
@@ -111,7 +111,7 @@ STRETCH_TYPES = ('undefined', 'normal', 'ultra_condensed', 'extra_condensed',
                  'condensed', 'semi_condensed', 'semi_expanded', 'expanded',
                  'extra_expanded', 'ultra_expanded', 'any')
 
-#: (:class:`collections.Sequence`) The list of style types for fonts
+#: (:class:`collections.abc.Sequence`) The list of style types for fonts
 #:
 #: - ``'undefined;``
 #: - ``'normal'``
@@ -120,7 +120,7 @@ STRETCH_TYPES = ('undefined', 'normal', 'ultra_condensed', 'extra_condensed',
 #: - ``'any'``
 STYLE_TYPES = ('undefined', 'normal', 'italic', 'oblique', 'any')
 
-#: (:class:`collections.Sequence`) The list of LineCap types
+#: (:class:`collections.abc.Sequence`) The list of LineCap types
 #:
 #: - ``'undefined;``
 #: - ``'butt'``
@@ -128,7 +128,7 @@ STYLE_TYPES = ('undefined', 'normal', 'italic', 'oblique', 'any')
 #: - ``'square'``
 LINE_CAP_TYPES = ('undefined', 'butt', 'round', 'square')
 
-#: (:class:`collections.Sequence`) The list of LineJoin types
+#: (:class:`collections.abc.Sequence`) The list of LineJoin types
 #:
 #: - ``'undefined'``
 #: - ``'miter'``
@@ -137,7 +137,7 @@ LINE_CAP_TYPES = ('undefined', 'butt', 'round', 'square')
 LINE_JOIN_TYPES = ('undefined', 'miter', 'round', 'bevel')
 
 
-#: (:class:`collections.Sequence`) The list of paint method types.
+#: (:class:`collections.abc.Sequence`) The list of paint method types.
 #:
 #: - ``'undefined'``
 #: - ``'point'``
@@ -381,7 +381,7 @@ class Drawing(Resource):
 
     @property
     def font_resolution(self):
-        """(:class:`~collections.Sequence`) The current font resolution. It also
+        """(:class:`~collections.abc.Sequence`) The current font resolution. It also
         can be set.
 
         .. versionadded:: 0.4.0
@@ -394,7 +394,7 @@ class Drawing(Resource):
 
     @font_resolution.setter
     def font_resolution(self, resolution):
-        if not isinstance(resolution, collections.Sequence):
+        if not isinstance(resolution, abc.Sequence):
             raise TypeError('expected sequence, not ' + repr(resolution))
         if len(resolution) != 2:
             raise ValueError('expected sequence of 2 floats')
@@ -558,7 +558,7 @@ class Drawing(Resource):
 
     @property
     def stroke_dash_array(self):
-        """(:class:`~collections.Sequence`) - (:class:`numbers.Real`) An array
+        """(:class:`~collections.abc.Sequence`) - (:class:`numbers.Real`) An array
         representing the pattern of dashes & gaps used to stroke paths.
         It also can be set.
 
@@ -929,12 +929,12 @@ class Drawing(Resource):
 
         :param matrix: a list of :class:`~numbers.Real` to define affine
                        matrix ``[sx, rx, ry, sy, tx, ty]``
-        :type matrix: :class:`collections.Sequence`
+        :type matrix: :class:`collections.abc.Sequence`
 
         .. versionadded:: 0.4.0
 
         """
-        if not isinstance(matrix, collections.Sequence) or len(matrix) != 6:
+        if not isinstance(matrix, abc.Sequence) or len(matrix) != 6:
             raise ValueError('matrix must be a list of size Real numbers')
         for idx, val in enumerate(matrix):
             if not isinstance(val, numbers.Real):
@@ -990,13 +990,13 @@ class Drawing(Resource):
 
         :param start: (:class:`~numbers.Real`, :class:`numbers.Real`)
                       pair which represents starting x and y of the arc
-        :type start: :class:`~collections.Sequence`
+        :type start: :class:`~collections.abc.Sequence`
         :param end: (:class:`~numbers.Real`, :class:`numbers.Real`)
                       pair which represents ending x and y of the arc
-        :type end: :class:`~collections.Sequence`
+        :type end: :class:`~collections.abc.Sequence`
         :param degree: (:class:`~numbers.Real`, :class:`numbers.Real`)
                       pair which represents starting degree, and ending degree
-        :type degree: :class:`~collections.Sequence`
+        :type degree: :class:`~collections.abc.Sequence`
 
         .. versionadded:: 0.4.0
 
@@ -1045,10 +1045,10 @@ class Drawing(Resource):
 
         :param origin: (:class:`~numbers.Real`, :class:`numbers.Real`)
                        pair which represents origin x and y of circle
-        :type origin: :class:`collections.Sequence`
+        :type origin: :class:`collections.abc.Sequence`
         :param perimeter: (:class:`~numbers.Real`, :class:`numbers.Real`)
                        pair which represents perimeter x and y of circle
-        :type perimeter: :class:`collections.Sequence`
+        :type perimeter: :class:`collections.abc.Sequence`
 
         .. versionadded:: 0.4.0
 
@@ -1193,14 +1193,14 @@ class Drawing(Resource):
 
         :param origin: (:class:`~numbers.Real`, :class:`numbers.Real`)
                        pair which represents origin x and y of circle
-        :type origin: :class:`collections.Sequence`
+        :type origin: :class:`collections.abc.Sequence`
         :param radius: (:class:`~numbers.Real`, :class:`numbers.Real`)
                        pair which represents radius x and radius y of circle
-        :type radius: :class:`collections.Sequence`
+        :type radius: :class:`collections.abc.Sequence`
         :param rotation: (:class:`~numbers.Real`, :class:`numbers.Real`)
                          pair which represents start and end of ellipse.
                          Default (0,360)
-        :type rotation: :class:`collections.Sequence`
+        :type rotation: :class:`collections.abc.Sequence`
 
         .. versionadded:: 0.4.0
 
@@ -1248,10 +1248,10 @@ class Drawing(Resource):
 
         :param start: (:class:`~numbers.Integral`, :class:`numbers.Integral`)
                       pair which represents starting x and y of the line
-        :type start: :class:`collections.Sequence`
+        :type start: :class:`collections.abc.Sequence`
         :param end: (:class:`~numbers.Integral`, :class:`numbers.Integral`)
                     pair which represents ending x and y of the line
-        :type end: :class:`collections.Sequence`
+        :type end: :class:`collections.abc.Sequence`
 
         """
         start_x, start_y = start
@@ -1321,10 +1321,10 @@ class Drawing(Resource):
 
         :param to: (:class:`~numbers.Real`, :class:`numbers.Real`)
                    pair which represents coordinates to draw to
-        :type to: :class:`collections.Sequence`
+        :type to: :class:`collections.abc.Sequence`
         :param controls: (:class:`~numbers.Real`, :class:`numbers.Real`)
                          coordinate to used to influence curve
-        :type controls: :class:`collections.Sequence`
+        :type controls: :class:`collections.abc.Sequence`
         :param smooth: :class:`bool` assume last defined control coordinate
         :type smooth: :class:`bool`
         :param relative: treat given coordinates as relative to current point
@@ -1372,10 +1372,10 @@ class Drawing(Resource):
 
         :param to: (:class:`~numbers.Real`, :class:`numbers.Real`)
                    pair which represents coordinates to draw to
-        :type to: :class:`collections.Sequence`
+        :type to: :class:`collections.abc.Sequence`
         :param control: (:class:`~numbers.Real`, :class:`numbers.Real`)
                         coordinate to used to influence curve
-        :type control: :class:`collections.Sequence`
+        :type control: :class:`collections.abc.Sequence`
         :param smooth: assume last defined control coordinate
         :type smooth: :class:`bool`
         :param relative: treat given coordinates as relative to current point
@@ -1433,10 +1433,10 @@ class Drawing(Resource):
 
         :param to: (:class:`~numbers.Real`, :class:`numbers.Real`)
                    pair which represents coordinates to draw to
-        :type to: :class:`collections.Sequence`
+        :type to: :class:`collections.abc.Sequence`
         :param radius: (:class:`~numbers.Real`, :class:`numbers.Real`)
                        pair which represents the radii of the ellipse to draw
-        :type radius: :class:`collections.Sequence`
+        :type radius: :class:`collections.abc.Sequence`
         :param rotate: degree to rotate ellipse on x-axis
         :type rotate: :class:`~numbers.Real`
         :param large_arc: draw largest available arc
@@ -1512,7 +1512,7 @@ class Drawing(Resource):
 
         :param to: (:class:`~numbers.Real`, :class:`numbers.Real`)
                       pair which represents coordinates to draw to.
-        :type to: :class:`collections.Sequence`
+        :type to: :class:`collections.abc.Sequence`
         :param relative: :class:`bool`
                     treat given coordinates as relative to current point
         :type relative: :class:`bool`
@@ -1536,7 +1536,7 @@ class Drawing(Resource):
 
         :param to: (:class:`~numbers.Real`, :class:`numbers.Real`)
                       pair which represents coordinates to draw to.
-        :type to: :class:`collections.Sequence`
+        :type to: :class:`collections.abc.Sequence`
         :param relative: :class:`bool`
                     treat given coordinates as relative to current point
         :type relative: :class:`bool`

--- a/wand/image.py
+++ b/wand/image.py
@@ -10,7 +10,6 @@ error happened)::
         print('height =', i.height)
 
 """
-import collections
 import ctypes
 import functools
 import numbers
@@ -19,7 +18,7 @@ import weakref
 from . import compat
 from .api import MagickPixelPacket, PixelInfo, libc, libmagick, library
 from .color import Color
-from .compat import (binary, binary_type, encode_filename, file_types,
+from .compat import (abc, binary, binary_type, encode_filename, file_types,
                      PY3, string_type, text, xrange)
 from .exceptions import MissingDelegateError, WandException
 from .font import Font
@@ -717,7 +716,8 @@ if MAGICK_VERSION_NUMBER >= 0x700:
                           'voronoi')
 
 
-#: (:class:`collections.Set`) The set of available :attr:`~BaseImage.options`.
+#: (:class:`collections.abc.Set`) The set of available
+#: :attr:`~BaseImage.options`.
 #:
 #: .. versionadded:: 0.3.0
 #:
@@ -889,7 +889,7 @@ class BaseImage(Resource):
     #:    Added ``'pdf:use-cropbox'`` option.
     options = None
 
-    #: (:class:`collections.Sequence`) The list of
+    #: (:class:`collections.abc.Sequence`) The list of
     #: :class:`~wand.sequence.SingleImage`\ s that the image contains.
     #:
     #: .. versionadded:: 0.3.0
@@ -919,7 +919,7 @@ class BaseImage(Resource):
 
     def __getitem__(self, idx):
         if (not isinstance(idx, string_type) and
-                isinstance(idx, collections.Iterable)):
+                isinstance(idx, abc.Iterable)):
             idx = tuple(idx)
             d = len(idx)
             if not (1 <= d <= 2):
@@ -987,7 +987,7 @@ class BaseImage(Resource):
         elif not isinstance(color, Color):
             raise TypeError('color must be in instance of Color, not ' +
                             repr(color))
-        if not isinstance(idx, collections.Iterable):
+        if not isinstance(idx, abc.Iterable):
             raise TypeError('Expecting list of x,y coordinates, not ' +
                             repr(idx))
         idx = tuple(idx)
@@ -1653,7 +1653,7 @@ class BaseImage(Resource):
     @page.setter
     @manipulative
     def page(self, newpage):
-        if isinstance(newpage, collections.Sequence):
+        if isinstance(newpage, abc.Sequence):
             w, h, x, y = newpage
         else:
             raise TypeError("page layout must be 4-tuple")
@@ -1754,7 +1754,7 @@ class BaseImage(Resource):
     @resolution.setter
     @manipulative
     def resolution(self, geometry):
-        if isinstance(geometry, collections.Sequence):
+        if isinstance(geometry, abc.Sequence):
             x, y = geometry
         elif isinstance(geometry, numbers.Real):
             x, y = geometry, geometry
@@ -2533,7 +2533,7 @@ class BaseImage(Resource):
         :type method: :class:`basestring`
         :param arguments: List of distorting float arguments
                           unique to distortion method
-        :type arguments: :class:`collections.Sequence`
+        :type arguments: :class:`collections.abc.Sequence`
         :param best_fit: Attempt to resize resulting image fit distortion.
                          Defaults False
         :type best_fit: :class:`bool`
@@ -2543,7 +2543,7 @@ class BaseImage(Resource):
         if method not in DISTORTION_METHODS:
             raise ValueError('expected string from DISTORTION_METHODS, not ' +
                              repr(method))
-        if not isinstance(arguments, collections.Sequence):
+        if not isinstance(arguments, abc.Sequence):
             raise TypeError('expected sequence of doubles, not ' +
                             repr(arguments))
         argc = len(arguments)
@@ -2718,7 +2718,7 @@ class BaseImage(Resource):
                         be calculated as.
         :type storage: :class:`basestring`
         :returns: list of values.
-        :rtype: :class:`collections.Sequence`
+        :rtype: :class:`collections.abc.Sequence`
 
         .. versionadded:: 0.5.0
         """
@@ -2891,7 +2891,7 @@ class BaseImage(Resource):
         :param function: a string listed in :const:`FUNCTION_TYPES`
         :type function: :class:`basestring`
         :param arguments: a sequence of doubles to apply against ``function``
-        :type arguments: :class:`collections.Sequence`
+        :type arguments: :class:`collections.abc.Sequence`
         :param channel: optional :const:`CHANNELS`, defaults all
         :type channel: :class:`basestring`
         :raises ValueError: when a ``function``, or ``channel`` is not
@@ -2903,7 +2903,7 @@ class BaseImage(Resource):
         if function not in FUNCTION_TYPES:
             raise ValueError('expected string from FUNCTION_TYPES, not ' +
                              repr(function))
-        if not isinstance(arguments, collections.Sequence):
+        if not isinstance(arguments, abc.Sequence):
             raise TypeError('expecting sequence of arguments, not ' +
                             repr(arguments))
         argc = len(arguments)
@@ -3150,7 +3150,7 @@ class BaseImage(Resource):
             if channel not in valid_channels:
                 raise ValueError('Unknown channel label: ' +
                                  repr(channel))
-        if not isinstance(data, collections.Sequence):
+        if not isinstance(data, abc.Sequence):
             raise TypeError('data must list of values, not' +
                             repr(data))
         # Ensure enough data was given.
@@ -4559,7 +4559,7 @@ class Image(BaseImage):
     :type background: :class:`wand.color.Color`
     :param resolution: set a resolution value (dpi),
                        useful for vectorial formats (like pdf)
-    :type resolution: :class:`collections.Sequence`,
+    :type resolution: :class:`collections.abc.Sequence`,
                       :Class:`numbers.Integral`
 
     .. versionadded:: 0.1.5
@@ -4959,7 +4959,7 @@ class Image(BaseImage):
         :type filename: :class:`basestring`
         :param resolution: set a resolution value (DPI),
                            useful for vectorial formats (like PDF)
-        :type resolution: :class:`collections.Sequence`,
+        :type resolution: :class:`collections.abc.Sequence`,
                           :class:`numbers.Integral`
 
         .. versionadded:: 0.3.0
@@ -4968,7 +4968,7 @@ class Image(BaseImage):
         r = None
         # Resolution must be set after image reading.
         if resolution is not None:
-            if (isinstance(resolution, collections.Sequence) and
+            if (isinstance(resolution, abc.Sequence) and
                     len(resolution) == 2):
                 library.MagickSetResolution(self.wand, *resolution)
             elif isinstance(resolution, numbers.Integral):
@@ -4989,7 +4989,7 @@ class Image(BaseImage):
                 blob = file.read()
                 file = None
         if blob is not None:
-            if not isinstance(blob, collections.Iterable):
+            if not isinstance(blob, abc.Iterable):
                 raise TypeError('blob must be iterable, not ' +
                                 repr(blob))
             if not isinstance(blob, binary_type):
@@ -5053,7 +5053,7 @@ class Image(BaseImage):
                 self.raise_exception()
 
 
-class Iterator(Resource, collections.Iterator):
+class Iterator(Resource, abc.Iterator):
     """Row iterator for :class:`Image`. It shouldn't be instantiated
     directly; instead, it can be acquired through :class:`Image` instance::
 
@@ -5067,7 +5067,7 @@ class Iterator(Resource, collections.Iterator):
                 assert isinstance(col, wand.color.Color)
                 print(col)
 
-    Every row is a :class:`collections.Sequence` which consists of
+    Every row is a :class:`collections.abc.Sequence` which consists of
     one or more :class:`wand.color.Color` values.
 
     :param image: the image to get an iterator
@@ -5187,7 +5187,7 @@ class ImageProperty(object):
         )
 
 
-class OptionDict(ImageProperty, collections.MutableMapping):
+class OptionDict(ImageProperty, abc.MutableMapping):
     """Free-form mutable mapping of global internal settings.
 
     .. versionadded:: 0.3.0
@@ -5227,7 +5227,7 @@ class OptionDict(ImageProperty, collections.MutableMapping):
         self[key] = ''
 
 
-class Metadata(ImageProperty, collections.MutableMapping):
+class Metadata(ImageProperty, abc.MutableMapping):
     """Class that implements dict-like read-only access to image metadata
     like EXIF or IPTC headers. Most WRITE encoders will ignore properties
     assigned here.
@@ -5315,7 +5315,7 @@ class Metadata(ImageProperty, collections.MutableMapping):
         return num.value
 
 
-class ArtifactTree(ImageProperty, collections.MutableMapping):
+class ArtifactTree(ImageProperty, abc.MutableMapping):
     """Splay tree to map image artifacts. Values defined here
     are intended to be used elseware, and will not be written
     to the encoded image.
@@ -5416,7 +5416,7 @@ class ArtifactTree(ImageProperty, collections.MutableMapping):
         return num.value
 
 
-class ProfileDict(ImageProperty, collections.MutableMapping):
+class ProfileDict(ImageProperty, abc.MutableMapping):
     """The mapping table of embedded image profiles.
 
     Use this to get, set, and delete whole profile payloads on an image. Each
@@ -5496,7 +5496,7 @@ class ProfileDict(ImageProperty, collections.MutableMapping):
             self.image.raise_exception()
 
 
-class ChannelImageDict(ImageProperty, collections.Mapping):
+class ChannelImageDict(ImageProperty, abc.Mapping):
     """The mapping table of separated images of the particular channel
     from the image.
 
@@ -5534,7 +5534,7 @@ class ChannelImageDict(ImageProperty, collections.Mapping):
         return img
 
 
-class ChannelDepthDict(ImageProperty, collections.Mapping):
+class ChannelDepthDict(ImageProperty, abc.Mapping):
     """The mapping table of channels to their depth.
 
     :param image: an image instance
@@ -5569,7 +5569,7 @@ class ChannelDepthDict(ImageProperty, collections.Mapping):
         return int(depth)
 
 
-class HistogramDict(collections.Mapping):
+class HistogramDict(abc.Mapping):
     """Specialized mapping object to represent color histogram.
     Keys are colors, and values are the number of pixels.
 

--- a/wand/resource.py
+++ b/wand/resource.py
@@ -5,13 +5,12 @@ There is the global resource to manage in MagickWand API. This module
 implements automatic global resource management through reference counting.
 
 """
-import collections
 import contextlib
 import ctypes
 import warnings
 
 from .api import libmagick, library
-from .compat import string_type
+from .compat import abc, string_type
 from .exceptions import TYPE_MAP, WandException
 from .version import MAGICK_VERSION_NUMBER
 
@@ -245,7 +244,7 @@ class DestroyedResourceError(WandException, ReferenceError, AttributeError):
     """
 
 
-class ResourceLimits(collections.MutableMapping):
+class ResourceLimits(abc.MutableMapping):
     """Wrapper for MagickCore resource limits.
     Useful for dynamically reducing system resources before attempting risky,
     or slow running, :class:`~wand.image.Image` operations.

--- a/wand/sequence.py
+++ b/wand/sequence.py
@@ -4,23 +4,22 @@
 .. versionadded:: 0.3.0
 
 """
-import collections
 import contextlib
 import ctypes
 import numbers
 
 from .api import libmagick, library
-from .compat import binary, xrange
+from .compat import abc, binary, xrange
 from .image import BaseImage, ImageProperty
 from .version import MAGICK_VERSION_INFO
 
 __all__ = 'Sequence', 'SingleImage'
 
 
-class Sequence(ImageProperty, collections.MutableSequence):
+class Sequence(ImageProperty, abc.MutableSequence):
     """The list-like object that contains every :class:`SingleImage`
     in the :class:`~wand.image.Image` container.  It implements
-    :class:`collections.Sequence` protocol.
+    :class:`collections.abc.Sequence` protocol.
 
     .. versionadded:: 0.3.0
 


### PR DESCRIPTION
Python 3.8 will drop support for
importing abstract base classes directly from collections module.
On python 3.7, direct import raises deprecation warning.

See https://docs.python.org/3/library/collections.html