### PR TITLE
Support collections in python3.7 or higher

### DIFF
--- a/wand/compat.py
+++ b/wand/compat.py
@@ -19,10 +19,11 @@ __all__ = ('PY3', 'abc', 'binary', 'binary_type', 'encode_filename',
 
 #: (:class:`bool`) Whether it is Python 3.x or not.
 PY3 = sys.version_info >= (3,)
-
+#: (:class:`bool`) Whether it is Python 3.7 or not.
+PY3_latest = sys.version_info >= (3,7)
 #: (:class:`module`) Module containing abstract base classes.
 #: :mod:`collections` in Python 2 and :mod:`collections.abc` in Python 3.
-abc = collections.abc if PY3 else collections
+abc = collections.abc if PY3 and not PY3_latest else collections
 
 #: (:class:`type`) Type for representing binary data.  :class:`str` in Python 2
 #: and :class:`bytes` in Python 3.


### PR DESCRIPTION
No new collections ABCs were added in Python 3.7

If use `compat.py` in Python3.7.2
```
>>> import collections
>>> abc = collections.abc
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/user/anaconda3/envs/py37/lib/python3.7/collections/__init__.py", line 55, in __getattr__
    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
AttributeError: module 'collections' has no attribute 'abc'
```
You can find `__getattr__` in `collections/__init__.py`
```
def __getattr__(name):
    # For backwards compatibility, continue to make the collections ABCs
    # through Python 3.6 available through the collections module.
    # Note, no new collections ABCs were added in Python 3.7
    if name in _collections_abc.__all__:
        obj = getattr(_collections_abc, name)
        import warnings
        warnings.warn("Using or importing the ABCs from 'collections' instead "
                      "of from 'collections.abc' is deprecated, "
                      "and in 3.8 it will stop working",
                      DeprecationWarning, stacklevel=2)
        globals()[name] = obj
        return obj
    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
```