### PR TITLE
import collections.abc explicitely

### DIFF
--- a/wand/compat.py
+++ b/wand/compat.py
@@ -7,7 +7,10 @@ multiple Python versions (2.6, 2.7, 3.3+) and VM implementations
 
 """
 import collections
-import collections.abc
+try:
+    import collections.abc
+except ImportError:
+    pass
 import contextlib
 import io
 import sys

--- a/wand/compat.py
+++ b/wand/compat.py
@@ -7,6 +7,7 @@ multiple Python versions (2.6, 2.7, 3.3+) and VM implementations
 
 """
 import collections
+import collections.abc
 import contextlib
 import io
 import sys


### PR DESCRIPTION
When using wand I get the following error message:
```
Traceback (most recent call last):
  File "preprocess.py", line 6, in <module>
    from wand.image import Image
  File "/usr/lib/python3.7/site-packages/wand/image.py", line 18, in <module>
    from . import compat
  File "/usr/lib/python3.7/site-packages/wand/compat.py", line 25, in <module>
    abc = collections.abc if PY3 else collections
  File "/usr/lib/python3.7/collections/__init__.py", line 55, in __getattr__
    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
AttributeError: module 'collections' has no attribute 'abc'
```
My Python Versiin is 3.7.2. I found under [1] a statement, that abc was formerly in collections - I assume not anymore. Added a single import statement in compat.py, and the error was gone. 

[1] https://docs.python.org/3/library/collections.abc.html