### PR TITLE
Fix typo in error messages Magick{Read|Ping}Image: occurs -> occur

### DIFF
--- a/wand/image.py
+++ b/wand/image.py
@@ -8478,7 +8478,7 @@ class Image(BaseImage):
         if not r:
             instance.raise_exception()
             msg = ('MagickPingImage returns false, but did raise ImageMagick '
-                   'exception. This can occurs when a delegate is missing, or '
+                   'exception. This can occur when a delegate is missing, or '
                    'returns EXIT_SUCCESS without generating a raster.')
             raise WandRuntimeError(msg)
         else:
@@ -8774,7 +8774,7 @@ class Image(BaseImage):
         if not r:
             self.raise_exception()
             msg = ('MagickReadImage returns false, but did not raise '
-                   'ImageMagick  exception. This can occurs when a delegate '
+                   'ImageMagick  exception. This can occur when a delegate '
                    'is missing, or returns EXIT_SUCCESS without generating a '
                    'raster.')
             raise WandRuntimeError(msg)


### PR DESCRIPTION
Found a minor typo in some error messages.