### PR TITLE
Fix "RuntimeError: dictionary changed size during iteration"

### DIFF
--- a/wand/resource.py
+++ b/wand/resource.py
@@ -59,7 +59,7 @@ def allocate_ref(addr, deallocator):
 
 def deallocate_ref(addr):
     global allocation_map
-    if addr in allocation_map:
+    if addr in list(allocation_map):
         deallocator = allocation_map.pop(addr)
         if callable(deallocator):
             deallocator(addr)
@@ -68,7 +68,7 @@ def deallocate_ref(addr):
 @atexit.register
 def shutdown():
     global allocation_map
-    for addr in allocation_map:
+    for addr in list(allocation_map):
         deallocator = allocation_map.pop(addr)
         if callable(deallocator):
             deallocator(addr)


### PR DESCRIPTION
This was introduced by 447ddb727c87b8329483ea5d6a70924345f6821e and caused tests to fail with PyPy3.

```
Traceback (most recent call last):
  File "/var/tmp/portage/dev-python/wand-0.6.0/work/Wand-0.6.0/wand/resource.py", line 71, in shutdown
    for addr in allocation_map:
RuntimeError: dictionary changed size during iteration
debug: OperationError:
debug:  operror-type: RuntimeError
debug:  operror-value: dictionary changed size during iteration
```

CPython raises an error too but still returns an exit code of 0.

447ddb727c87b8329483ea5d6a70924345f6821e was pushed just before releasing 0.6.0 so I never had a chance to test it.

Do you think you'll make a minor release for this or should I patch 0.6.0 for Gentoo?