### PR TITLE
Make the documentation reproducible

### DIFF
--- a/docs/wand/api.rst
+++ b/docs/wand/api.rst
@@ -1,4 +1,7 @@
 
 .. automodule:: wand.api
    :members:
+   :exclude-members: libc
+   :exclude-members: library
+   :exclude-members: libmagick
 


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort we noticed that `wand` could not be built reproducibly. This was due to the documentation including the nondeterministic memory references in the documentation.

This bug was originally filed in Debian as [#961582](https://bugs.debian.org/961582).