### PR TITLE
Buffer overflow in Image.connected_components with ImageMagick 7.0.10

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -14,6 +14,7 @@ Version 0.6.3
 
 Unreleased.
 
+ - Fixed buffer overflow bug in :meth:`Image.connected_components() <wand.image.BaseImage.connected_components>` method. [:issue:`496`]
  - Added :meth:`Image.data_url() <wand.image.Image.data_url>` method. [:issue:`489`]
  - Added :attr:`Image.sampling_factors <wand.image.BaseImage.sampling_factors>` property. [:issue:`491`]
  - Added :meth:`Image.encipher() <wand.image.BaseImage.encipher>` & :meth:`Image.decipher() <wand.image.BaseImage.decipher>` methods.

--- a/wand/cdefs/structures.py
+++ b/wand/cdefs/structures.py
@@ -3,11 +3,12 @@
 
 .. versionadded:: 0.5.0
 """
-from ctypes import POINTER, Structure, c_double, c_int, c_size_t
+from ctypes import POINTER, Structure, c_bool, c_double, c_int, c_size_t
 from wand.cdefs.wandtypes import c_ssize_t, c_magick_real_t, c_magick_size_t
 
-__all__ = ('AffineMatrix', 'ChannelFeature', 'GeometryInfo', 'KernelInfo',
-           'MagickPixelPacket', 'PixelInfo', 'PointInfo', 'RectangleInfo')
+__all__ = ('AffineMatrix', 'CCMaxMetrics', 'CCObjectInfo', 'CCObjectInfo70A',
+           'ChannelFeature', 'GeometryInfo', 'KernelInfo', 'MagickPixelPacket',
+           'PixelInfo', 'PointInfo', 'RectangleInfo')
 
 
 class AffineMatrix(Structure):
@@ -171,6 +172,21 @@ class CCObjectInfo(Structure):
                 ('centroid', PointInfo),
                 ('area', c_double),
                 ('census', c_double)]
+
+
+CCMaxMetrics = 16
+
+
+class CCObjectInfo70A(Structure):
+    CCMaxMetrics = CCMaxMetrics
+    _fields_ = [('_id', c_ssize_t),
+                ('bounding_box', RectangleInfo),
+                ('color', PixelInfo),
+                ('centroid', PointInfo),
+                ('area', c_double),
+                ('census', c_double),
+                ('merge', c_bool),
+                ('metric', c_double * CCMaxMetrics)]
 
 
 # All this will change with IM7, so let's not implement this just yet.

--- a/wand/image.py
+++ b/wand/image.py
@@ -3978,6 +3978,7 @@ class BaseImage(Resource):
                 src_addr = objects_ptr.value + (i * ccoi_mem_size)
                 ctypes.memmove(ctypes.addressof(temp), src_addr, ccoi_mem_size)
                 objects.append(ConnectedComponentObject(temp))
+                del temp
             objects_ptr = libmagick.RelinquishMagickMemory(objects_ptr)
         else:
             self.raise_exception()


### PR DESCRIPTION
Fixes #496

Extend CCObjectInfo C structure for upstreams changes from MagickCore. This is likely to change over time, so we'll have to create "versioned" intermediate python `ctypes.Structure`