### PR TITLE
Add pcc64le jobs to travis. Install libmagickwand-dev for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,28 @@
 dist: bionic
 language: python
 sudo: false
+arch:
+- amd64
+- ppc64le
 git:
    depth: 1
 python:
 - 3.7
 - 3.8
 - pypy3
+# Disable version pypy3 for ppc64le
+jobs:
+    exclude:
+     - arch: ppc64le
+       python: pypy3
 env:
 - secure: "EhG2uSD2m1eGxuL2HeQewJJx7MVL4WpjrxyfiUBEgsApemD1yKJPjUnLwAyd\nbPi5HJx5ySm1TTRSvj6/yP85YLYTaJHA8OabKk7p0wFW294qcrYIDGovU7NL\n3YOqZmqN+S3XOBGFCOnByxE+pcxxWW/3/I09EgeW7D6tBPh67G0="
+before_install:
+  - >
+    if [[ "$TRAVIS_CPU_ARCH" == ppc64le ]]; then
+      sudo apt-get update;
+      sudo apt-get -y install libmagickwand-dev;
+    fi 
 install:
 - echo $TRAVIS_PYTHON_VERSION
 - pip install -U pytest pytest-xdist coveralls


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.