### PR TITLE
Replace `c_magick_char_p` & remove memory leaks. Issue #510

### DIFF
--- a/tests/drawing_test.py
+++ b/tests/drawing_test.py
@@ -72,7 +72,7 @@ def test_set_get_font(fx_wand, fx_asset):
 
 
 def test_set_get_font_family(fx_wand):
-    assert fx_wand.font_family is None
+    assert fx_wand.font_family == ''
     fx_wand.font_family = 'sans-serif'
     assert fx_wand.font_family == 'sans-serif'
     with raises(TypeError):

--- a/tests/drawing_test.py
+++ b/tests/drawing_test.py
@@ -72,7 +72,7 @@ def test_set_get_font(fx_wand, fx_asset):
 
 
 def test_set_get_font_family(fx_wand):
-    assert fx_wand.font_family == ''
+    assert fx_wand.font_family == None
     fx_wand.font_family = 'sans-serif'
     assert fx_wand.font_family == 'sans-serif'
     with raises(TypeError):

--- a/wand/cdefs/core.py
+++ b/wand/cdefs/core.py
@@ -4,7 +4,7 @@
 .. versionadded:: 0.5.0
 """
 from ctypes import POINTER, c_void_p, c_char_p, c_int, c_size_t
-from wand.cdefs.wandtypes import c_magick_char_p, c_ssize_t
+from wand.cdefs.wandtypes import c_ssize_t
 
 __all__ = ('load', 'load_with_version')
 
@@ -81,7 +81,7 @@ def load(libmagick):
     libmagick.GetNextImageInList.argtypes = [c_void_p]
     libmagick.GetNextImageInList.restype = c_void_p
     libmagick.MagickToMime.argtypes = [c_char_p]
-    libmagick.MagickToMime.restype = c_magick_char_p
+    libmagick.MagickToMime.restype = c_void_p
     try:
         libmagick.ParseAbsoluteGeometry.argtypes = [c_char_p, c_void_p]
         libmagick.ParseAbsoluteGeometry.restype = c_int

--- a/wand/cdefs/drawing_wand.py
+++ b/wand/cdefs/drawing_wand.py
@@ -5,7 +5,7 @@
 """
 from ctypes import (POINTER, c_void_p, c_char_p, c_double, c_int, c_uint,
                     c_size_t, c_ubyte, c_ulong)
-from wand.cdefs.wandtypes import c_magick_char_p, c_ssize_t
+from wand.cdefs.wandtypes import c_ssize_t
 from wand.cdefs.structures import PointInfo
 
 __all__ = ('load',)
@@ -45,7 +45,7 @@ def load(lib, IM_VERSION):
     lib.IsDrawingWand.argtypes = [c_void_p]
     lib.IsDrawingWand.restype = c_int
     lib.DrawGetException.argtypes = [c_void_p, POINTER(c_int)]
-    lib.DrawGetException.restype = c_magick_char_p
+    lib.DrawGetException.restype = c_void_p
     lib.DrawClearException.argtypes = [c_void_p]
     lib.DrawClearException.restype = c_int
     lib.DrawAffine.argtypes = [c_void_p, c_void_p]
@@ -112,7 +112,7 @@ def load(lib, IM_VERSION):
     ]
     lib.DrawGetBorderColor.argtypes = [c_void_p, c_void_p]
     lib.DrawGetClipPath.argtypes = [c_void_p]
-    lib.DrawGetClipPath.restype = c_magick_char_p
+    lib.DrawGetClipPath.restype = c_void_p
     lib.DrawGetClipRule.argtypes = [c_void_p]
     lib.DrawGetClipRule.restype = c_uint
     lib.DrawGetClipUnits.argtypes = [c_void_p]
@@ -142,9 +142,9 @@ def load(lib, IM_VERSION):
     lib.DrawGetStrokeWidth.argtypes = [c_void_p]
     lib.DrawGetStrokeWidth.restype = c_double
     lib.DrawGetFont.argtypes = [c_void_p]
-    lib.DrawGetFont.restype = c_magick_char_p
+    lib.DrawGetFont.restype = c_void_p
     lib.DrawGetFontFamily.argtypes = [c_void_p]
-    lib.DrawGetFontFamily.restype = c_magick_char_p
+    lib.DrawGetFontFamily.restype = c_void_p
     lib.DrawGetFontResolution.argtypes = [
         c_void_p, POINTER(c_double), POINTER(c_double)
     ]
@@ -169,7 +169,7 @@ def load(lib, IM_VERSION):
     except AttributeError:
         lib.DrawGetTextDirection = None
     lib.DrawGetTextEncoding.argtypes = [c_void_p]
-    lib.DrawGetTextEncoding.restype = c_magick_char_p
+    lib.DrawGetTextEncoding.restype = c_void_p
     try:
         lib.DrawGetTextInterlineSpacing.argtypes = [c_void_p]
         lib.DrawGetTextInterlineSpacing.restype = c_double
@@ -181,7 +181,7 @@ def load(lib, IM_VERSION):
     lib.DrawGetTextKerning.restype = c_double
     lib.DrawGetTextUnderColor.argtypes = [c_void_p, c_void_p]
     lib.DrawGetVectorGraphics.argtypes = [c_void_p]
-    lib.DrawGetVectorGraphics.restype = c_magick_char_p
+    lib.DrawGetVectorGraphics.restype = c_void_p
     lib.DrawSetGravity.argtypes = [c_void_p, c_int]
     lib.DrawGetGravity.argtypes = [c_void_p]
     lib.DrawGetGravity.restype = c_int

--- a/wand/cdefs/magick_image.py
+++ b/wand/cdefs/magick_image.py
@@ -5,7 +5,7 @@
 """
 from ctypes import (CFUNCTYPE, POINTER, c_void_p, c_int, c_size_t, c_double,
                     c_char_p, c_ubyte, c_bool)
-from wand.cdefs.wandtypes import c_ssize_t, c_magick_char_p
+from wand.cdefs.wandtypes import c_ssize_t
 
 __all__ = ('MagickProgressMonitor', 'load')
 
@@ -485,9 +485,9 @@ def load(lib, IM_VERSION):
         lib.MagickGetImageFeatures.argtypes = [c_void_p, c_size_t]
         lib.MagickGetImageFeatures.restype = c_void_p
     lib.MagickGetImageFilename.argtypes = [c_void_p]
-    lib.MagickGetImageFilename.restype = c_magick_char_p
+    lib.MagickGetImageFilename.restype = c_void_p
     lib.MagickGetImageFormat.argtypes = [c_void_p]
-    lib.MagickGetImageFormat.restype = c_magick_char_p
+    lib.MagickGetImageFormat.restype = c_void_p
     lib.MagickGetImageFuzz.argtypes = [c_void_p]
     lib.MagickGetImageFuzz.restype = c_double
     lib.MagickGetImageGamma.argtypes = [c_void_p]
@@ -574,7 +574,7 @@ def load(lib, IM_VERSION):
     lib.MagickGetImageScene.argtypes = [c_void_p]
     lib.MagickGetImageScene.restype = c_size_t
     lib.MagickGetImageSignature.argtypes = [c_void_p]
-    lib.MagickGetImageSignature.restype = c_magick_char_p
+    lib.MagickGetImageSignature.restype = c_void_p
     lib.MagickGetImageTicksPerSecond.argtypes = [c_void_p]
     lib.MagickGetImageTicksPerSecond.restype = c_size_t
     lib.MagickGetImageTotalInkDensity.argtypes = [c_void_p]
@@ -617,7 +617,7 @@ def load(lib, IM_VERSION):
     else:
         lib.MagickHoughLineImage = None
     lib.MagickIdentifyImage.argtypes = [c_void_p]
-    lib.MagickIdentifyImage.restype = c_magick_char_p
+    lib.MagickIdentifyImage.restype = c_void_p
     if is_im_6:
         lib.MagickImplodeImage.argtypes = [c_void_p, c_double]
     else:

--- a/wand/cdefs/magick_property.py
+++ b/wand/cdefs/magick_property.py
@@ -5,7 +5,7 @@
 """
 from ctypes import (POINTER, c_void_p, c_char_p, c_size_t, c_ubyte, c_uint,
                     c_int, c_ulong, c_double, c_bool)
-from wand.cdefs.wandtypes import c_magick_char_p, c_ssize_t
+from wand.cdefs.wandtypes import c_ssize_t
 
 __all__ = ('load',)
 
@@ -55,7 +55,7 @@ def load(lib, IM_VERSION):
     lib.MagickGetGravity.argtypes = [c_void_p]
     lib.MagickGetGravity.restype = c_int
     lib.MagickGetImageArtifact.argtypes = [c_void_p, c_char_p]
-    lib.MagickGetImageArtifact.restype = c_magick_char_p
+    lib.MagickGetImageArtifact.restype = c_void_p
     lib.MagickGetImageArtifacts.argtypes = [
         c_void_p, c_char_p, POINTER(c_size_t)
     ]
@@ -69,11 +69,11 @@ def load(lib, IM_VERSION):
     ]
     lib.MagickGetImageProfiles.restype = POINTER(c_char_p)
     lib.MagickGetImageProperty.argtypes = [c_void_p, c_char_p]
-    lib.MagickGetImageProperty.restype = c_magick_char_p
+    lib.MagickGetImageProperty.restype = c_void_p
     lib.MagickGetImageProperties.argtypes = [
         c_void_p, c_char_p, POINTER(c_size_t)
     ]
-    lib.MagickGetImageProperties.restype = POINTER(c_char_p)
+    lib.MagickGetImageProperties.restype = POINTER(c_void_p)
     lib.MagickGetInterlaceScheme.argtypes = [c_void_p]
     lib.MagickGetInterlaceScheme.restype = c_int
     lib.MagickGetOption.argtypes = [c_void_p, c_char_p]
@@ -90,15 +90,15 @@ def load(lib, IM_VERSION):
     lib.MagickGetSize.argtypes = [c_void_p, POINTER(c_uint), POINTER(c_uint)]
     lib.MagickGetSize.restype = c_int
     lib.MagickQueryConfigureOption.argtypes = [c_char_p]
-    lib.MagickQueryConfigureOption.restype = c_magick_char_p
+    lib.MagickQueryConfigureOption.restype = c_void_p
     lib.MagickQueryConfigureOptions.argtypes = [c_char_p, POINTER(c_size_t)]
-    lib.MagickQueryConfigureOptions.restype = POINTER(c_magick_char_p)
+    lib.MagickQueryConfigureOptions.restype = POINTER(c_void_p)
     lib.MagickQueryFontMetrics.argtypes = [c_void_p, c_void_p, c_char_p]
     lib.MagickQueryFontMetrics.restype = POINTER(c_double)
     lib.MagickQueryFonts.argtypes = [c_char_p, POINTER(c_size_t)]
-    lib.MagickQueryFonts.restype = POINTER(c_magick_char_p)
+    lib.MagickQueryFonts.restype = POINTER(c_void_p)
     lib.MagickQueryFormats.argtypes = [c_char_p, POINTER(c_size_t)]
-    lib.MagickQueryFormats.restype = POINTER(c_magick_char_p)
+    lib.MagickQueryFormats.restype = POINTER(c_void_p)
     lib.MagickQueryMultilineFontMetrics.argtypes = [
         c_void_p, c_void_p, c_char_p
     ]

--- a/wand/cdefs/magick_property.py
+++ b/wand/cdefs/magick_property.py
@@ -51,7 +51,7 @@ def load(lib, IM_VERSION):
     lib.MagickGetCompressionQuality.argtypes = [c_void_p]
     lib.MagickGetCompressionQuality.restype = c_size_t
     lib.MagickGetFont.argtypes = [c_void_p]
-    lib.MagickGetFont.restype = c_char_p
+    lib.MagickGetFont.restype = c_void_p
     lib.MagickGetGravity.argtypes = [c_void_p]
     lib.MagickGetGravity.restype = c_int
     lib.MagickGetImageArtifact.argtypes = [c_void_p, c_char_p]
@@ -59,7 +59,7 @@ def load(lib, IM_VERSION):
     lib.MagickGetImageArtifacts.argtypes = [
         c_void_p, c_char_p, POINTER(c_size_t)
     ]
-    lib.MagickGetImageArtifacts.restype = POINTER(c_char_p)
+    lib.MagickGetImageArtifacts.restype = POINTER(c_void_p)
     lib.MagickGetImageProfile.argtypes = [
         c_void_p, c_char_p, POINTER(c_size_t)
     ]
@@ -67,7 +67,7 @@ def load(lib, IM_VERSION):
     lib.MagickGetImageProfiles.argtypes = [
         c_void_p, c_char_p, POINTER(c_size_t)
     ]
-    lib.MagickGetImageProfiles.restype = POINTER(c_char_p)
+    lib.MagickGetImageProfiles.restype = POINTER(c_void_p)
     lib.MagickGetImageProperty.argtypes = [c_void_p, c_char_p]
     lib.MagickGetImageProperty.restype = c_void_p
     lib.MagickGetImageProperties.argtypes = [
@@ -77,7 +77,7 @@ def load(lib, IM_VERSION):
     lib.MagickGetInterlaceScheme.argtypes = [c_void_p]
     lib.MagickGetInterlaceScheme.restype = c_int
     lib.MagickGetOption.argtypes = [c_void_p, c_char_p]
-    lib.MagickGetOption.restype = c_char_p
+    lib.MagickGetOption.restype = c_void_p
     lib.MagickGetPointsize.argtypes = [c_void_p]
     lib.MagickGetPointsize.restype = c_double
     lib.MagickGetQuantumRange.argtypes = [POINTER(c_size_t)]

--- a/wand/cdefs/magick_wand.py
+++ b/wand/cdefs/magick_wand.py
@@ -4,7 +4,7 @@
 .. versionadded:: 0.5.0
 """
 from ctypes import POINTER, c_void_p, c_bool, c_int
-from wand.cdefs.wandtypes import c_ssize_t, c_magick_char_p
+from wand.cdefs.wandtypes import c_ssize_t
 
 __all__ = ('load',)
 
@@ -47,7 +47,7 @@ def load(lib, IM_VERSION):
         pass
     lib.MagickClearException.argtypes = [c_void_p]
     lib.MagickGetException.argtypes = [c_void_p, POINTER(c_int)]
-    lib.MagickGetException.restype = c_magick_char_p
+    lib.MagickGetException.restype = c_void_p
     lib.MagickGetExceptionType.argtypes = [c_void_p]
     lib.MagickGetExceptionType.restype = c_int
     lib.MagickGetIteratorIndex.argtypes = [c_void_p]

--- a/wand/cdefs/pixel_iterator.py
+++ b/wand/cdefs/pixel_iterator.py
@@ -4,7 +4,7 @@
 .. versionadded:: 0.5.0
 """
 from ctypes import POINTER, c_void_p, c_int, c_size_t
-from wand.cdefs.wandtypes import c_ssize_t, c_magick_char_p
+from wand.cdefs.wandtypes import c_ssize_t
 
 __all__ = ('load',)
 
@@ -42,7 +42,7 @@ def load(lib, IM_VERSION):
     lib.NewPixelIterator.restype = c_void_p
     lib.PixelClearIteratorException.argtypes = [c_void_p]
     lib.PixelGetIteratorException.argtypes = [c_void_p, POINTER(c_int)]
-    lib.PixelGetIteratorException.restype = c_magick_char_p
+    lib.PixelGetIteratorException.restype = c_void_p
     lib.PixelGetNextIteratorRow.argtypes = [c_void_p, POINTER(c_size_t)]
     lib.PixelGetNextIteratorRow.restype = POINTER(c_void_p)
     lib.PixelSetFirstIteratorRow.argtypes = [c_void_p]

--- a/wand/cdefs/pixel_wand.py
+++ b/wand/cdefs/pixel_wand.py
@@ -6,7 +6,6 @@
 from ctypes import (CDLL, POINTER, c_char_p, c_double,
                     c_float, c_int, c_longdouble, c_size_t,
                     c_ubyte, c_uint, c_ushort, c_void_p)
-from wand.cdefs.wandtypes import c_magick_char_p
 import numbers
 import platform
 
@@ -100,9 +99,9 @@ def load(lib, IM_VERSION, IM_QUANTUM_DEPTH, IM_HDRI):
     lib.PixelGetBlueQuantum.argtypes = [c_void_p]
     lib.PixelGetBlueQuantum.restype = QuantumType
     lib.PixelGetColorAsNormalizedString.argtypes = [c_void_p]
-    lib.PixelGetColorAsNormalizedString.restype = c_magick_char_p
+    lib.PixelGetColorAsNormalizedString.restype = c_void_p
     lib.PixelGetColorAsString.argtypes = [c_void_p]
-    lib.PixelGetColorAsString.restype = c_magick_char_p
+    lib.PixelGetColorAsString.restype = c_void_p
     lib.PixelGetColorCount.argtypes = [c_void_p]
     lib.PixelGetColorCount.restype = c_size_t
     lib.PixelGetCyan.argtypes = [c_void_p]
@@ -110,7 +109,7 @@ def load(lib, IM_VERSION, IM_QUANTUM_DEPTH, IM_HDRI):
     lib.PixelGetCyanQuantum.argtypes = [c_void_p]
     lib.PixelGetCyanQuantum.restype = QuantumType
     lib.PixelGetException.argtypes = [c_void_p, POINTER(c_int)]
-    lib.PixelGetException.restype = c_magick_char_p
+    lib.PixelGetException.restype = c_void_p
     lib.PixelGetExceptionType.argtypes = [c_void_p]
     lib.PixelGetExceptionType.restype = c_int
     lib.PixelGetFuzz.argtypes = [c_void_p]

--- a/wand/cdefs/wandtypes.py
+++ b/wand/cdefs/wandtypes.py
@@ -8,34 +8,7 @@ import os
 import platform
 import sys
 
-__all__ = ('c_magick_char_p', 'c_magick_real_t', 'c_magick_size_t',
-           'c_ssize_t')
-
-
-class c_magick_char_p(ctypes.c_char_p):
-    """This subclass prevents the automatic conversion behavior of
-    :class:`ctypes.c_char_p`, allowing memory to be properly freed in the
-    destructor.  It must only be used for non-const character pointers
-    returned by ImageMagick functions.
-
-    """
-
-    def __del__(self):
-        """Relinquishes memory allocated by ImageMagick.
-        We don't need to worry about checking for ``NULL`` because
-        :c:func:`MagickRelinquishMemory` does that for us.
-        Note also that :class:`ctypes.c_char_p` has no
-        :meth:`~object.__del__` method, so we don't need to
-        (and indeed can't) call the superclass destructor.
-
-        """
-        try:
-            from wand.api import library  # Lazy load global library
-            library.MagickRelinquishMemory(self)
-        except ImportError:
-            # Python my be shutting down; and such, ``sys.meta_path``
-            # may not be available.
-            pass
+__all__ = ('c_magick_real_t', 'c_magick_size_t', 'c_ssize_t')
 
 
 if not hasattr(ctypes, 'c_ssize_t'):

--- a/wand/cdefs/wandtypes.py
+++ b/wand/cdefs/wandtypes.py
@@ -24,7 +24,7 @@ class c_magick_char_p(ctypes.c_char_p):
         """Relinquishes memory allocated by ImageMagick.
         We don't need to worry about checking for ``NULL`` because
         :c:func:`MagickRelinquishMemory` does that for us.
-        Note alslo that :class:`ctypes.c_char_p` has no
+        Note also that :class:`ctypes.c_char_p` has no
         :meth:`~object.__del__` method, so we don't need to
         (and indeed can't) call the superclass destructor.
 

--- a/wand/color.py
+++ b/wand/color.py
@@ -613,13 +613,12 @@ class Color(Resource):
 
         """
         with self:
+            string = None
             ptr = library.PixelGetColorAsNormalizedString(self.resource)
             if ptr:
-                string = ctypes.string_at(ptr)
+                string = text(ctypes.string_at(ptr))
                 ptr = library.MagickRelinquishMemory(ptr)
-            else:
-                string = b''
-            return text(string)
+            return string
 
     @property
     def red(self):
@@ -671,13 +670,12 @@ class Color(Resource):
     def string(self):
         """(:class:`basestring`) The string representation of the color."""
         with self:
+            color_string = None
             ptr = library.PixelGetColorAsString(self.resource)
             if ptr:
-                color_string = ctypes.string_at(ptr)
+                color_string = text(ctypes.string_at(ptr))
                 ptr = library.MagickRelinquishMemory(ptr)
-            else:
-                color_string = b''
-            return text(color_string)
+            return color_string
 
     @property
     def yellow(self):

--- a/wand/color.py
+++ b/wand/color.py
@@ -613,8 +613,13 @@ class Color(Resource):
 
         """
         with self:
-            string = library.PixelGetColorAsNormalizedString(self.resource)
-            return text(string.value)
+            ptr = library.PixelGetColorAsNormalizedString(self.resource)
+            if ptr:
+                string = ctypes.string_at(ptr)
+                ptr = library.MagickRelinquishMemory(ptr)
+            else:
+                string = b''
+            return text(string)
 
     @property
     def red(self):
@@ -666,8 +671,13 @@ class Color(Resource):
     def string(self):
         """(:class:`basestring`) The string representation of the color."""
         with self:
-            color_string = library.PixelGetColorAsString(self.resource)
-            return text(color_string.value)
+            ptr = library.PixelGetColorAsString(self.resource)
+            if ptr:
+                color_string = ctypes.string_at(ptr)
+                ptr = library.MagickRelinquishMemory(ptr)
+            else:
+                color_string = b''
+            return text(color_string)
 
     @property
     def yellow(self):

--- a/wand/drawing.py
+++ b/wand/drawing.py
@@ -218,7 +218,12 @@ class Drawing(Resource):
 
         """
         clip_path_p = library.DrawGetClipPath(self.resource)
-        return text(clip_path_p.value)
+        if clip_path_p:
+            clip_path_str = ctypes.string_at(clip_path_p)
+            clip_path_p = library.MagickRelinquishMemory(clip_path_p)
+        else:
+            clip_path_str = b''
+        return text(clip_path_str)
 
     @clip_path.setter
     def clip_path(self, path):
@@ -325,7 +330,12 @@ class Drawing(Resource):
 
         """
         font_p = library.DrawGetFont(self.resource)
-        return text(font_p.value)
+        if font_p:
+            font_str = ctypes.string_at(font_p)
+            font_p = library.MagickRelinquishMemory(font_p)
+        else:
+            font_str = b''
+        return text(font_str)
 
     @font.setter
     def font(self, font):
@@ -344,7 +354,12 @@ class Drawing(Resource):
 
         """
         font_family_p = library.DrawGetFontFamily(self.resource)
-        return text(font_family_p.value)
+        if font_family_p:
+            font_family_str = ctypes.string_at(font_family_p)
+            font_family_p = library.MagickRelinquishMemory(font_family_p)
+        else:
+            font_family_str = b''
+        return text(font_family_str)
 
     @font_family.setter
     def font_family(self, family):
@@ -529,10 +544,10 @@ class Drawing(Resource):
             self.resource, ctypes.byref(number_elements)
         )
         dash_array = []
-        if dash_array_p is not None:
+        if dash_array_p:
             dash_array = [float(dash_array_p[i])
                           for i in xrange(number_elements.value)]
-            library.MagickRelinquishMemory(dash_array_p)
+            dash_array_p = library.MagickRelinquishMemory(dash_array_p)
         return dash_array
 
     @stroke_dash_array.setter
@@ -730,7 +745,12 @@ class Drawing(Resource):
 
         """
         text_encoding_p = library.DrawGetTextEncoding(self.resource)
-        return text(text_encoding_p.value)
+        if text_encoding_p:
+            text_encoding_str = ctypes.string_at(text_encoding_p)
+            text_encoding_p = library.MagickRelinquishMemory(text_encoding_p)
+        else:
+            text_encoding_str = b''
+        return text(text_encoding_str)
 
     @text_encoding.setter
     def text_encoding(self, encoding):
@@ -826,8 +846,13 @@ class Drawing(Resource):
            :c:func:`MagickRelinquishMemory` instead of :c:func:`libc.free`.
 
         """
-        vector_graphics_p = library.DrawGetVectorGraphics(self.resource)
-        return '<wand>' + text(vector_graphics_p.value) + '</wand>'
+        vg_p = library.DrawGetVectorGraphics(self.resource)
+        if vg_p:
+            vg_str = ctypes.string_at(vg_p)
+            vg_p = library.MagickRelinquishMemory(vg_p)
+        else:
+            vg_str = b''
+        return '<wand>' + text(vg_str) + '</wand>'
 
     @vector_graphics.setter
     def vector_graphics(self, vector_graphics):
@@ -1156,7 +1181,7 @@ class Drawing(Resource):
             # Generate a generic error if ImageMagick couldn't emit one.
             raise ValueError('Unable to render text with current font.')
         args = [result[i] for i in xrange(13)]
-        library.MagickRelinquishMemory(result)
+        result = library.MagickRelinquishMemory(result)
         return FontMetrics(*args)
 
     def line(self, start, end):

--- a/wand/drawing.py
+++ b/wand/drawing.py
@@ -217,13 +217,12 @@ class Drawing(Resource):
            :c:func:`MagickRelinquishMemory` instead of :c:func:`libc.free`.
 
         """
+        clip_path_str = None
         clip_path_p = library.DrawGetClipPath(self.resource)
         if clip_path_p:
-            clip_path_str = ctypes.string_at(clip_path_p)
+            clip_path_str = text(ctypes.string_at(clip_path_p))
             clip_path_p = library.MagickRelinquishMemory(clip_path_p)
-        else:
-            clip_path_str = b''
-        return text(clip_path_str)
+        return clip_path_str
 
     @clip_path.setter
     def clip_path(self, path):
@@ -329,13 +328,12 @@ class Drawing(Resource):
            :c:func:`MagickRelinquishMemory` instead of :c:func:`libc.free`.
 
         """
+        font_str = None
         font_p = library.DrawGetFont(self.resource)
         if font_p:
-            font_str = ctypes.string_at(font_p)
+            font_str = text(ctypes.string_at(font_p))
             font_p = library.MagickRelinquishMemory(font_p)
-        else:
-            font_str = b''
-        return text(font_str)
+        return font_str
 
     @font.setter
     def font(self, font):
@@ -353,13 +351,12 @@ class Drawing(Resource):
            :c:func:`MagickRelinquishMemory` instead of :c:func:`libc.free`.
 
         """
+        font_family_str = None
         font_family_p = library.DrawGetFontFamily(self.resource)
         if font_family_p:
-            font_family_str = ctypes.string_at(font_family_p)
+            font_family_str = text(ctypes.string_at(font_family_p))
             font_family_p = library.MagickRelinquishMemory(font_family_p)
-        else:
-            font_family_str = b''
-        return text(font_family_str)
+        return font_family_str
 
     @font_family.setter
     def font_family(self, family):
@@ -744,13 +741,12 @@ class Drawing(Resource):
            :c:func:`MagickRelinquishMemory` instead of :c:func:`libc.free`.
 
         """
+        text_encoding_str = None
         text_encoding_p = library.DrawGetTextEncoding(self.resource)
         if text_encoding_p:
-            text_encoding_str = ctypes.string_at(text_encoding_p)
+            text_encoding_str = text(ctypes.string_at(text_encoding_p))
             text_encoding_p = library.MagickRelinquishMemory(text_encoding_p)
-        else:
-            text_encoding_str = b''
-        return text(text_encoding_str)
+        return text_encoding_str
 
     @text_encoding.setter
     def text_encoding(self, encoding):

--- a/wand/image.py
+++ b/wand/image.py
@@ -1764,12 +1764,12 @@ class BaseImage(Resource):
         It also can be set.
 
         """
-        font_str = b''
+        font_str = None
         font_p = library.MagickGetFont(self.wand)
         if font_p:
-            font_str = ctypes.string_at(font_p)
+            font_str = text(ctypes.string_at(font_p))
             font_p = library.MagickRelinquishMemory(font_p)
-        return text(font_str)
+        return font_str
 
     @font_path.setter
     @manipulative
@@ -1817,13 +1817,12 @@ class BaseImage(Resource):
         .. versionadded:: 0.1.6
 
         """
+        fmt_str = None
         fmt_p = library.MagickGetImageFormat(self.wand)
         if fmt_p:
-            fmt_str = ctypes.string_at(fmt_p)
+            fmt_str = text(ctypes.string_at(fmt_p))
             fmt_p = library.MagickRelinquishMemory(fmt_p)
-        else:
-            fmt_str = b''
-        return text(fmt_str)
+        return fmt_str
 
     @format.setter
     def format(self, fmt):
@@ -2417,13 +2416,12 @@ class BaseImage(Resource):
         .. versionadded:: 0.1.9
 
         """
+        sig_str = None
         sig_p = library.MagickGetImageSignature(self.wand)
         if sig_p:
-            sig_str = ctypes.string_at(sig_p)
+            sig_str = text(ctypes.string_at(sig_p))
             sig_p = library.MagickRelinquishMemory(sig_p)
-        else:
-            sig_str = b''
-        return text(sig_str)
+        return sig_str
 
     @property
     def size(self):
@@ -9386,13 +9384,12 @@ class Image(BaseImage):
         .. versionadded:: 0.1.7
 
         """
+        mtype = None
         rp = libmagick.MagickToMime(binary(self.format))
-        if bool(rp):
-            mtype = ctypes.string_at(rp)
+        if rp:
+            mtype = text(ctypes.string_at(rp))
             rp = libmagick.DestroyString(rp)
-        else:
-            self.raise_exception()
-        return text(mtype)
+        return mtype
 
     def blank(self, width, height, background=None):
         """Creates blank image.
@@ -9890,11 +9887,11 @@ class OptionDict(ImageProperty, abc.MutableMapping):
         opt_str = b''
         opt_p = library.MagickGetOption(self.image.wand, binary(key))
         if opt_p:
-            opt_str = ctypes.string_at(opt_p)
+            opt_str = text(ctypes.string_at(opt_p))
             opt_p = library.MagickRelinquishMemory(opt_p)
         else:
             raise KeyError(key)
-        return text(opt_str)
+        return opt_str
 
     def __setitem__(self, key, value):
         assertions.assert_string(key=key, value=value)
@@ -9940,11 +9937,11 @@ class Metadata(ImageProperty, abc.MutableMapping):
         value = b''
         vp = library.MagickGetImageProperty(image.wand, binary(k))
         if vp:
-            value = ctypes.string_at(vp)
+            value = text(ctypes.string_at(vp))
             vp = library.MagickRelinquishMemory(vp)
         else:
             raise KeyError(k)
-        return text(value)
+        return value
 
     def __setitem__(self, k, v):
         """
@@ -10034,16 +10031,16 @@ class ArtifactTree(ImageProperty, abc.MutableMapping):
         vs = b''
         vp = library.MagickGetImageArtifact(image.wand, binary(k))
         if vp:
-            vs = ctypes.string_at(vp)
+            vs = text(ctypes.string_at(vp))
             vp = library.MagickRelinquishMemory(vp)
         if len(vs) < 1:
             vp = library.MagickGetImageProperty(image.wand, binary(k))
             if vp:
-                vs = ctypes.string_at(vp)
+                vs = text(ctypes.string_at(vp))
                 vp = library.MagickRelinquishMemory(vp)
-        if len(vs) < 1:
-            return None
-        return text(vs)
+            else:
+                vs = None
+        return vs
 
     def __setitem__(self, k, v):
         """

--- a/wand/resource.py
+++ b/wand/resource.py
@@ -15,7 +15,7 @@ from .compat import abc, string_type, text
 from .exceptions import TYPE_MAP, WandException
 from .version import MAGICK_VERSION_NUMBER
 
-__all__ = ('genesis', 'limits', 'safe_copy', 'shutdown', 'terminus',
+__all__ = ('genesis', 'limits', 'shutdown', 'terminus',
            'DestroyedResourceError', 'Resource', 'ResourceLimits')
 
 
@@ -69,27 +69,13 @@ def deallocate_ref(addr):
 def shutdown():
     global allocation_map
     for addr in list(allocation_map):
-        deallocator = allocation_map.pop(addr)
-        if callable(deallocator):
-            deallocator(addr)
+        try:
+            deallocator = allocation_map.pop(addr)
+            if callable(deallocator):
+                deallocator(addr)
+        except KeyError:
+            pass
     terminus()
-
-
-def safe_copy(ptr):
-    """Safely cast memory address to char pointer, convert to python string,
-    and immediately free resources.
-
-    :param ptr: The memory address to convert to text string.
-    :type ptr: :class:`ctypes.c_void_p`
-    :returns: :class:`tuple` (:class:`ctypes.c_void_p`, :class:`str`)
-
-    .. versionadded:: 0.5.3
-    """
-    string = None
-    if bool(ptr):
-        string = text(ctypes.cast(ptr, ctypes.c_char_p).value)
-        ptr = library.MagickRelinquishMemory(ptr)  # Force pointer to zero
-    return ptr, string
 
 
 class Resource(object):

--- a/wand/resource.py
+++ b/wand/resource.py
@@ -11,7 +11,7 @@ import ctypes
 import warnings
 
 from .api import library
-from .compat import abc, string_type, text
+from .compat import abc, string_type
 from .exceptions import TYPE_MAP, WandException
 from .version import MAGICK_VERSION_NUMBER
 

--- a/wand/resource.py
+++ b/wand/resource.py
@@ -213,10 +213,16 @@ class Resource(object):
         severity = ctypes.c_int()
         desc = self.c_get_exception(self.resource, ctypes.byref(severity))
         if severity.value == 0:
+            if desc:
+                desc = library.MagickRelinquishMemory(desc)
             return
         self.c_clear_exception(self.resource)
         exc_cls = TYPE_MAP[severity.value]
-        message = desc.value
+        if desc:
+            message = ctypes.string_at(desc)
+            desc = library.MagickRelinquishMemory(desc)
+        else:
+            message = b''
         if not isinstance(message, string_type):
             message = message.decode(errors='replace')
         return exc_cls(message)

--- a/wand/sequence.py
+++ b/wand/sequence.py
@@ -255,7 +255,7 @@ class Sequence(ImageProperty, abc.MutableSequence):
                                              ctypes.byref(length))
         if blob_p and length.value:
             blob = ctypes.string_at(blob_p, length.value)
-            library.MagickRelinquishMemory(blob_p)
+            blob_p = library.MagickRelinquishMemory(blob_p)
             return blob
         else:
             return None

--- a/wand/version.py
+++ b/wand/version.py
@@ -183,12 +183,14 @@ def configure_options(pattern='*'):
     configs = {}
     configs_p = library.MagickQueryConfigureOptions(pattern_p,
                                                     ctypes.byref(config_count))
-    cursor = 0
-    while cursor < config_count.value:
-        config = configs_p[cursor].value
-        value = library.MagickQueryConfigureOption(config)
-        configs[text(config)] = text(value.value)
-        cursor += 1
+    for cursor in range(config_count.value):
+        config = ctypes.string_at(configs_p[cursor])
+        val_p = library.MagickQueryConfigureOption(config)
+        if val_p:
+            configs[text(config)] = text(ctypes.string_at(val_p))
+            val_p = library.MagickRelinquishMemory(val_p)
+    if configs_p:
+        configs_p = library.MagickRelinquishMemory(configs_p)
     return configs
 
 
@@ -225,11 +227,11 @@ def fonts(pattern='*'):
     fonts = []
     fonts_p = library.MagickQueryFonts(pattern_p,
                                        ctypes.byref(number_fonts))
-    cursor = 0
-    while cursor < number_fonts.value:
-        font = fonts_p[cursor].value
+    for cursor in range(number_fonts.value):
+        font = ctypes.string_at(fonts_p[cursor])
         fonts.append(text(font))
-        cursor += 1
+    if fonts_p:
+        fonts_p = library.MagickRelinquishMemory(fonts_p)
     return fonts
 
 
@@ -259,11 +261,11 @@ def formats(pattern='*'):
     formats = []
     formats_p = library.MagickQueryFormats(pattern_p,
                                            ctypes.byref(number_formats))
-    cursor = 0
-    while cursor < number_formats.value:
-        value = formats_p[cursor].value
+    for cursor in range(number_formats.value):
+        value = ctypes.string_at(formats_p[cursor])
         formats.append(text(value))
-        cursor += 1
+    if formats_p:
+        formats_p = library.MagickRelinquishMemory(formats_p)
     return formats
 
 


### PR DESCRIPTION
This pull request retires `wand.cdefs.wandtypes.c_magick_char_p` with a direct "copy-n-free" approach. The need to do this was identified by issue #510 where blocks of memory flagged as unused were recycled before the garbage collector could call `__del__` methods. This resulted in random double-free deallocations, and unaligned memory chunk errors. 