### PR TITLE
Updated Alpline install symlinks

### DIFF
--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -246,6 +246,6 @@ You may need to create a couple symbolic links for the ImageMagick libraries.
 
 .. sourcecode:: console
 
-    # ln -s /usr/lib/libMagickCore-7.Q16HDRI.so.6 /usr/lib/libMagickCore-7.Q16HDRI.so
-    # ln -s /usr/lib/libMagickWand-7.Q16HDRI.so.6 /usr/lib/libMagickWand-7.Q16HDRI.so
+    # ln -s /usr/lib/libMagickCore-7.Q16HDRI.so.9 /usr/lib/libMagickCore-7.Q16HDRI.so
+    # ln -s /usr/lib/libMagickWand-7.Q16HDRI.so.9 /usr/lib/libMagickWand-7.Q16HDRI.so
 


### PR DESCRIPTION
I found when setting up Wand that the symlinks were out of date with Alpine Linux. They now use `.so.9` so I've updated the documentation to suit.