### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/guide/threshold.rst
+++ b/docs/guide/threshold.rst
@@ -223,7 +223,7 @@ Random Threshold
 
 .. versionadded:: 0.5.7
 
-Applies a random threshold between ``low`` & ``heigh`` values.
+Applies a random threshold between ``low`` & ``high`` values.
 
 .. code-block:: python
 

--- a/wand/api.py
+++ b/wand/api.py
@@ -14,7 +14,7 @@ import os.path
 import platform
 import sys
 import traceback
-# Forward import for backwords compatibility.
+# Forward import for backwards compatibility.
 from .cdefs.structures import (AffineMatrix, MagickPixelPacket, PixelInfo,
                                PointInfo)
 if platform.system() == "Windows":

--- a/wand/font.py
+++ b/wand/font.py
@@ -62,7 +62,7 @@ class Font(tuple):
        0, which means *autosized*.
 
     .. versionchanged:: 0.5.0
-       Added ``stroke_color`` & ``stoke_width`` paramaters.
+       Added ``stroke_color`` & ``stoke_width`` parameters.
     """
 
     def __new__(cls, path, size=0, color=None, antialias=True,

--- a/wand/image.py
+++ b/wand/image.py
@@ -2845,7 +2845,7 @@ class BaseImage(Resource):
 
         :param columns: width of resized image.
         :type columns: :class:`numbers.Integral`
-        :param rows: hight of resized image.
+        :param rows: height of resized image.
         :type rows: :class:`numbers.Integral`
 
         .. versionadded:: 0.5.3
@@ -3145,7 +3145,7 @@ class BaseImage(Resource):
     @manipulative
     @trap_exception
     def brightness_contrast(self, brightness=0.0, contrast=0.0, channel=None):
-        """Converts ``brightness`` & ``contrast`` paramaters into a slope &
+        """Converts ``brightness`` & ``contrast`` parameters into a slope &
         intercept, and applies a polynomial function.
 
         :param brightness: between ``-100.0`` and ``100.0``. Default is ``0.0``
@@ -7559,7 +7559,7 @@ class BaseImage(Resource):
                   pixels from left-to-right. Default value: ``0``.
         :type x: :class:`numbers.Integral`
         :param y: Number of rows to roll over. Negative value will roll
-                  pixels from bottomt-to-top, and positive value will roll
+                  pixels from bottom-to-top, and positive value will roll
                   pixels from top-to-bottm. Default value: ``0``.
         :type y: :class:`numbers.Integral`
 
@@ -8836,7 +8836,7 @@ class BaseImage(Resource):
                      two colors as the same. Value can be between ``0.0``,
                      and :attr:`quantum_range`.
         :type fuzz: :class:`numbers.Real`
-        :param reset_coords: Reset coordinates after triming image. Default
+        :param reset_coords: Reset coordinates after trimming image. Default
                              ``False``.
         :type reset_coords: :class:`bool`
         :param percent_background: Sets how aggressive the trim operation will
@@ -9903,7 +9903,7 @@ class Image(BaseImage):
         :type tile: :class:`basestring`
         :param thumbnail: Preferred image size. Montage will attempt to
                           generate a thumbnail to match the geometry. This
-                          can also define the border size on each thumbmail.
+                          can also define the border size on each thumbnail.
                           Example: ``"120x120x+4+3>"``.
         :type thumbnail: :class:`basestring`
         :param mode: Which effect to render. Options include ``"frame"``,


### PR DESCRIPTION
There are small typos in:
- docs/guide/threshold.rst
- wand/api.py
- wand/font.py
- wand/image.py

Fixes:
- Should read `parameters` rather than `paramaters`.
- Should read `trimming` rather than `triming`.
- Should read `thumbnail` rather than `thumbmail`.
- Should read `height` rather than `hight`.
- Should read `high` rather than `heigh`.
- Should read `bottom` rather than `bottomt`.
- Should read `backwards` rather than `backwords`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md