### PR TITLE
Call genesis before allocate yield. #587

### DIFF
--- a/wand/resource.py
+++ b/wand/resource.py
@@ -178,6 +178,7 @@ class Resource(object):
                 resource.resource = library.NewResource()
 
         """
+        genesis()
         yield self
 
     def destroy(self):


### PR DESCRIPTION
This one-liner should address the segfault issues reported on Apple's M1 arm64 chips.