### PR TITLE
Fix possible typo in method name

### DIFF
--- a/docs/guide/threshold.rst
+++ b/docs/guide/threshold.rst
@@ -318,7 +318,7 @@ unwanted colors.
     from wand.image import Image
 
     with Image(filename='inca_tern.jpg') as img:
-        img.threshold_threshold(threshold='#ace')
+        img.white_threshold(threshold='#ace')
         img.save(filename='threshold_white.jpg')
 
 +-------------------------------------+-------------------------------------------+


### PR DESCRIPTION
The method `threshold_threshold` doesn't exist, so I guess it is a typo and should be `white_threshold`.