### PR TITLE
Updated sizes for long & quantum storage types. Fixes #596

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,9 @@ Unreleased.
 
  - Fixed format issue when calling :meth:`Image.convert() <wand.image.Image.convert>`,
    and :meth:`Image.make_blob() <wand.image.Image.make_blob>` methods. [:issue:`594`]
+ - Fixed storage type size for `"long"` & `"quantum"` values in
+   :meth:`Image.export_pixels() <wand.image.BaseImage.export_pixels>` and
+   :meth:`Image.import_pixels() <wand.image.BaseImage.import_pixels>` methods. [:issue:`596`]
 
 
 .. _changelog-0.6.10:

--- a/wand/image.py
+++ b/wand/image.py
@@ -4879,6 +4879,9 @@ class BaseImage(Resource):
         :rtype: :class:`collections.abc.Sequence`
 
         .. versionadded:: 0.5.0
+
+        .. versionchanged:: 0.6.11
+           Update storage type size for `"long"` & `"quantum"` values.
         """
         _w, _h = self.size
         if width is None:
@@ -4901,8 +4904,8 @@ class BaseImage(Resource):
             ctypes.c_double,
             ctypes.c_float,
             ctypes.c_uint,
-            ctypes.c_ulong,
-            ctypes.c_double,  # FIXME: Might be c_longdouble?
+            ctypes.c_uint64,
+            library.PixelGetRedQuantum.restype,
             ctypes.c_ushort
         ]
         s_index = STORAGE_TYPES.index(storage)
@@ -5548,6 +5551,9 @@ class BaseImage(Resource):
         :type storage: :class:`basestring`
 
         .. versionadded:: 0.5.0
+
+        .. versionchanged:: 0.6.11
+           Update storage type size for `"long"` & `"quantum"` values.
         """
         _w, _h = self.size
         if width is None:
@@ -5582,8 +5588,8 @@ class BaseImage(Resource):
             ctypes.c_double,
             ctypes.c_float,
             ctypes.c_uint,
-            ctypes.c_ulong,
-            ctypes.c_double,  # FIXME: Might be c_longdouble ?
+            ctypes.c_uint64,
+            library.PixelGetRedQuantum.restype,
             ctypes.c_ushort
         ]
         s_index = STORAGE_TYPES.index(storage)


### PR DESCRIPTION
This PR enforces a fixed size for `storage_type="long"`, and reuses `QuantumType` defined in PixelWand cdefs.