### PR TITLE
Include filter support for Image.distort

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,7 @@ Unreleased.
  - Fixed storage type size for `"long"` & `"quantum"` values in
    :meth:`Image.export_pixels() <wand.image.BaseImage.export_pixels>` and
    :meth:`Image.import_pixels() <wand.image.BaseImage.import_pixels>` methods. [:issue:`596`]
+ - Added ``filter`` parameter to :meth:`Image.distort() <wand.image.BaseImage.distort>` method.
  - [TEST] Added Python 3.11 to regression tests for `github actions <https://github.com/emcconville/wand/actions>`_.
 
 

--- a/tests/image_methods_test.py
+++ b/tests/image_methods_test.py
@@ -699,35 +699,40 @@ def test_cycle_color_map(fx_asset):
             img.cycle_color_map('NaN')
 
 
-def test_deskew(fx_asset):
+def test_deskew():
     with Image(filename='rose:') as img:
         was = img.signature
         img.deskew(0.4 * img.quantum_range)
         assert was != img.signature
 
 
-def test_despeckle(fx_asset):
+def test_despeckle():
     with Image(filename='rose:') as img:
         was = img.signature
         img.despeckle()
         assert was != img.signature
 
 
-@mark.slow
-def test_distort(fx_asset):
+def test_distort():
     """Distort image."""
-    with Image(filename=str(fx_asset.join('checks.png'))) as img:
-        with Color('skyblue') as color:
-            img.matte_color = color
-            img.virtual_pixel = 'tile'
-            img.distort('perspective', (0, 0, 20, 60, 90, 0, 70, 63,
-                                        0, 90, 5, 83, 90, 90, 85, 88))
-            assert img[img.width - 1, 0] == color
+    with Image(filename='rose:') as img:
+        was = img.signature
+        w, h = img.size
+        img.distort('resize', (w*2, h*2))
+        neu = img.signature
+        assert was != neu
+    # Let's ensure a distorted image with a defined filter doesn't
+    # match default.
+    with Image(filename='rose:') as img:
+        was = img.signature
+        w, h = img.size
+        img.distort('resize', (w*2, h*2), filter='lanczos')
+        assert neu != img.signature
 
 
-def test_distort_error(fx_asset):
+def test_distort_error():
     """Distort image with user error"""
-    with Image(filename=str(fx_asset.join('mona-lisa.jpg'))) as img:
+    with Image(filename='rose:') as img:
         with raises(ValueError):
             img.distort('mirror', (1,))
         with raises(TypeError):
@@ -1247,25 +1252,25 @@ def test_level_channel(fx_asset):
         with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
             # Adjust each channel level to make it entirely black
             img.level(0.99, 1.0, channel=chan)
-            assert(getattr(img[0, 0], c) <= 0)
-            assert(getattr(img[0, -1], c) <= 0)
+            assert getattr(img[0, 0], c) <= 0
+            assert getattr(img[0, -1], c) <= 0
         with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
             # Adjust each channel level to make it entirely white
             img.level(0.0, 0.01, channel=chan)
-            assert(getattr(img[0, 0], c) >= 255)
-            assert(getattr(img[0, -1], c) >= 255)
+            assert getattr(img[0, 0], c) >= 255
+            assert getattr(img[0, -1], c) >= 255
         with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
             # Adjust each channel's gamma to darken its midtones
             img.level(gamma=0.5, channel=chan)
             with img[0, len(img) // 2] as light:
-                assert(getattr(light, c) <= 65)
-                assert(getattr(light, c) >= 60)
+                assert getattr(light, c) <= 65
+                assert getattr(light, c) >= 60
         with Image(filename=str(fx_asset.join('gray_range.jpg'))) as img:
             # Adjust each channel's gamma to lighten its midtones
             img.level(0, 1, 2.5, chan)
             with img[0, len(img) // 2] as light:
-                assert(getattr(light, c) >= 190)
-                assert(getattr(light, c) <= 195)
+                assert getattr(light, c) >= 190
+                assert getattr(light, c) <= 195
 
 
 def test_level_user_error(fx_asset):
@@ -1691,13 +1696,12 @@ def test_posterize(fx_asset):
             img.posterize(levels=16, dither='manhatten')
 
 
-@mark.slow
 def test_quantize(fx_asset):
-    number_colors = 64
-    with Image(width=100, height=100, pseudo='PLASMA:') as img:
+    number_colors = 32
+    with Image(width=100, height=100, pseudo='gradient:') as img:
         assert img.colors > number_colors
 
-    with Image(width=100, height=100, pseudo='PLASMA:') as img:
+    with Image(width=100, height=100, pseudo='gradient:') as img:
         with raises(TypeError):
             img.quantize(str(number_colors), 'undefined', 0, True, True)
 

--- a/wand/cdefs/core.py
+++ b/wand/cdefs/core.py
@@ -3,7 +3,8 @@
 
 .. versionadded:: 0.5.0
 """
-from ctypes import POINTER, c_void_p, c_char_p, c_int, c_size_t, c_ulonglong
+from ctypes import (POINTER, c_void_p, c_char_p, c_int, c_size_t,
+                    c_ulonglong, c_bool)
 from wand.cdefs.wandtypes import c_ssize_t
 
 __all__ = ('load', 'load_with_version')
@@ -28,12 +29,18 @@ def load(libmagick):
     """
     libmagick.AcquireExceptionInfo.argtypes = []
     libmagick.AcquireExceptionInfo.restype = c_void_p
+    libmagick.AcquireImageInfo.argtypes = []
+    libmagick.AcquireImageInfo.restype = c_void_p
+    libmagick.CloneImageInfo.argtypes = [c_void_p]
+    libmagick.CloneImageInfo.restype = c_void_p
     libmagick.CloneImages.argtypes = [c_void_p, c_char_p, c_void_p]
     libmagick.CloneImages.restype = c_void_p
     libmagick.DestroyExceptionInfo.argtypes = [c_void_p]
     libmagick.DestroyExceptionInfo.restype = c_void_p
     libmagick.DestroyImage.argtypes = [c_void_p]
     libmagick.DestroyImage.restype = c_void_p
+    libmagick.DestroyImageInfo.argtypes = [c_void_p]
+    libmagick.DestroyImageInfo.restype = c_void_p
     libmagick.DestroyString.argtypes = [c_void_p]
     libmagick.DestroyString.restype = c_void_p
     try:
@@ -104,8 +111,12 @@ def load(libmagick):
     except AttributeError:
         libmagick.ParseGeometry = None
         libmagick.ParseMetaGeometry = None
+    libmagick.SetImageOption.argtypes = [c_void_p, c_char_p, c_char_p]
+    libmagick.SetImageOption.restype = c_bool
     libmagick.SetMagickResourceLimit.argtypes = [c_int, c_ulonglong]
     libmagick.SetMagickResourceLimit.restype = c_int
+    libmagick.SyncImageSettings.argtypes = [c_void_p, c_void_p, c_void_p]
+    libmagick.SyncImageSettings.restype = c_bool
 
 
 def load_with_version(libmagick, IM_VERSION):

--- a/wand/cdefs/magick_image.py
+++ b/wand/cdefs/magick_image.py
@@ -487,6 +487,14 @@ def load(lib, IM_VERSION):
         lib.MagickGetImageFeatures.restype = c_void_p
     lib.MagickGetImageFilename.argtypes = [c_void_p]
     lib.MagickGetImageFilename.restype = c_void_p
+    if IM_VERSION >= 0x710:
+        try:
+            lib.MagickGetImageFilter.argtypes = [c_void_p]
+            lib.MagickGetImageFilter.restype = c_int
+        except AttributeError:
+            lib.MagickGetImageFilter = None
+    else:
+        lib.MagickGetImageFilter = None
     lib.MagickGetImageFormat.argtypes = [c_void_p]
     lib.MagickGetImageFormat.restype = c_void_p
     lib.MagickGetImageFuzz.argtypes = [c_void_p]
@@ -984,6 +992,14 @@ def load(lib, IM_VERSION):
     lib.MagickSetImageExtent.restype = c_bool
     lib.MagickSetImageFilename.argtypes = [c_void_p, c_char_p]
     lib.MagickSetImageFilename.restype = c_bool
+    if IM_VERSION >= 0x710:
+        try:
+            lib.MagickSetImageFilter.argtypes = [c_void_p, c_int]
+            lib.MagickSetImageFilter.restype = c_bool
+        except AttributeError:
+            lib.MagickSetImageFilter = None
+    else:
+        lib.MagickSetImageFilter = None
     lib.MagickSetImageFormat.argtypes = [c_void_p, c_char_p]
     lib.MagickSetImageFormat.restype = c_bool
     lib.MagickSetImageFuzz.argtypes = [c_void_p, c_double]

--- a/wand/cdefs/magick_property.py
+++ b/wand/cdefs/magick_property.py
@@ -52,6 +52,14 @@ def load(lib, IM_VERSION):
     lib.MagickGetCompressionQuality.restype = c_size_t
     lib.MagickGetFont.argtypes = [c_void_p]
     lib.MagickGetFont.restype = c_void_p
+    if IM_VERSION >= 0x710:
+        try:
+            lib.MagickGetFilter.argtypes = [c_void_p]
+            lib.MagickGetFilter.restype = c_int
+        except AttributeError:
+            lib.MagickGetFilter = None
+    else:
+        lib.MagickGetFilter = None
     lib.MagickGetGravity.argtypes = [c_void_p]
     lib.MagickGetGravity.restype = c_int
     lib.MagickGetImageArtifact.argtypes = [c_void_p, c_char_p]
@@ -123,6 +131,15 @@ def load(lib, IM_VERSION):
     lib.MagickSetExtract.restype = c_bool
     lib.MagickSetFilename.argtypes = [c_void_p, c_char_p]
     lib.MagickSetFilename.restype = c_bool
+    if IM_VERSION >= 0x710:
+        try:
+            lib.MagickSetFilter.argtypes = [c_void_p, c_int]
+            lib.MagickSetFilter.restype = c_bool
+        except AttributeError:
+            lib.MagickSetFilter = None
+    else:
+        lib.MagickSetFilter = None
+    lib.MagickSetFilter
     lib.MagickSetFont.argtypes = [c_void_p, c_char_p]
     lib.MagickSetFont.restype = c_bool
     lib.MagickSetFormat.argtypes = [c_void_p, c_char_p]


### PR DESCRIPTION
This PR adds the `filter=` parameter for the distort method.

```py
from wand.image import Image

with Image(filename='rose:') as img:
    img.distort('resize', (140, 92), filter='box')

```
This options came for discussion #601, and a upstream change in MagickWand's C-API .
