### PR TITLE
Make tests work with pytest 7.2.0 and without "py"

### DIFF
--- a/tests/misc_test.py
+++ b/tests/misc_test.py
@@ -1,7 +1,7 @@
 import datetime
 import numbers
 import re
-from py.test import mark, raises
+from pytest import mark, raises
 
 from wand.version import (MAGICK_VERSION, MAGICK_VERSION_INFO,
                           MAGICK_VERSION_NUMBER, MAGICK_RELEASE_DATE,


### PR DESCRIPTION
Hi,

pytest no longer requires the "py" package, see https://github.com/pytest-dev/pytest/commit/19dda7c9bdc8ef71c792e0f77a9595bfad8d9248

Because of this, tests would fail if "py" was not installed:
```
ModuleNotFoundError: No module named 'py.test'; 'py' is not a package
```

Originally reported as https://bugs.gentoo.org/888499

It would be nice if you could release a new version once this is fixed.
