### PR TITLE
docs: fix build with Sphinx 6.0.0 + fix typos

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -263,11 +263,11 @@ man_pages = [
 intersphinx_mapping = {'http://docs.python.org/': None}
 
 extlinks = {
-    'issue': ('https://github.com/emcconville/wand/issues/%s', '#'),
-    'pull': ('https://github.com/emcconville/wand/pull/%s', '!'),
-    'branch': ('https://github.com/emcconville/wand/compare/master...%s', ''),
-    'commit': ('https://github.com/emcconville/wand/commit/%s', ''),
-    'cli': ('https://imagemagick.org/script/command-line-options.php#%s', '-'),
+    'issue': ('https://github.com/emcconville/wand/issues/%s', '#%s'),
+    'pull': ('https://github.com/emcconville/wand/pull/%s', '!%s'),
+    'branch': ('https://github.com/emcconville/wand/compare/master...%s', '%s'),
+    'commit': ('https://github.com/emcconville/wand/commit/%s', '%s'),
+    'cli': ('https://imagemagick.org/script/command-line-options.php#%s', '-%s'),
 }
 
 # fall back if theme is not there

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -9,8 +9,8 @@ CFFI
    Wand will move to CFFI from ctypes.
 
 PIL compatibility layer
-   PIL has very long history and the most of Python projects still
-   depend on it.  We will work on PIL compatibility layer using Wand.
+   PIL has a very long history and most Python projects still
+   depend on it.  We will work on a PIL compatibility layer using Wand.
    It will provide two ways to emulate PIL:
 
    - Module-level compatibility which can be used by changing
@@ -26,10 +26,10 @@ PIL compatibility layer
          from wand.pilcompat.monkey import patch; patch()
          import PIL.Image  # it imports wand.pilcompat.Image module
 
-CLI (:program:`covert` command) to Wand compiler (:issue:`100`)
-   Primary interface of ImageMagick is :program:`convert` command.
+CLI (:program:`convert` command) to Wand compiler (:issue:`100`)
+   The primary interface of ImageMagick is the :program:`convert` command.
    It provides a small *parameter language*, and many answers on the Web
    contain code using this.  The problem is that you can't simply
-   copy-and-paste these code to utilize Wand.
+   copy-and-paste these snippets of code to utilize Wand.
 
    This feature is to make these CLI codes possible to be used with Wand.


### PR DESCRIPTION
Hi,
This fixes the build with Sphinx 6.0.0. This was initially reported here: https://bugs.gentoo.org/889906.
See https://github.com/sphinx-doc/sphinx/commit/93cf1a57d916a1ff96c8e8a0356d0256e40489ac for the breaking change.
I've also fixed some typos in the doc.