### PR TITLE
change load_library to return the paths of files that failed to load

### DIFF
--- a/wand/api.py
+++ b/wand/api.py
@@ -131,9 +131,15 @@ def load_library():
 
     """
     tried_paths = []
+    found_files = []
     for libwand_path, libmagick_path in library_paths():
         if libwand_path is None or libmagick_path is None:
             continue
+        if os.path.isfile(libwand_path) is True:
+            found_files.append(libwand_path)
+        if libwand_path != libmagick_path:
+            if os.path.isfile(libmagick_path) is True:
+                found_files.append(libmagick_path)
         try:
             tried_paths.append(libwand_path)
             libwand = ctypes.CDLL(str(libwand_path))
@@ -145,7 +151,7 @@ def load_library():
         except (IOError, OSError):
             continue
         return libwand, libmagick
-    raise IOError('cannot find library; tried paths: ' + repr(tried_paths))
+    raise IOError('cannot find compatible library; tried paths: ' + repr(tried_paths) + ' and failed to load files: ' + repr(found_files))
 
 
 try:


### PR DESCRIPTION
This is related to issue #645 , where the user received error message 
```
  File "/Users/<User>/opt/anaconda3/envs/<envname>/lib/python3.11/site-packages/wand/api.py", line 143, in load_library
    raise IOError('cannot find library; tried paths: ' + repr(tried_paths))
```
where tried_paths included a path with a library file. The root cause was that the file existed but could not be loaded as it was incompatible.

The new change includes in the error message that a file was found but was unable to be loaded correctly. This indicates to the user that they should check that file to make sure it's compatible with their system.
