### PR TITLE
Add notes for running on Apple Silicon

### DIFF
--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -75,6 +75,13 @@ Homebrew
 
          $ brew install imagemagick --with-liblqr
 
+   If you are running on a Mac with Apple Silicon, you will need to export
+   :envvar:`MAGICK_HOME` before using Wand. 
+
+   .. sourcecode:: console
+
+         $ export MAGICK_HOME=/opt/homebrew
+
 MacPorts
    .. sourcecode:: console
 


### PR DESCRIPTION
When running on Apple Silicon and using homebrew, you have to set MAGICK_HOME manually before it will work, and while there is a note for MacPorts, there isn't anything for homebrew.