### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/guide/cli.rst
+++ b/docs/guide/cli.rst
@@ -322,7 +322,7 @@ This table maps ImageMagick's CLI operators to Wand's
 CLI Options to Wand Properties
 ------------------------------
 
-This table list ImageMagick's options, and maps them to Wand's
+This table lists ImageMagick's options, and maps them to Wand's
 :class:`~wand.image.Image` properties.
 
 +------------------------+--------------------------------------------------+

--- a/docs/guide/colorspace.rst
+++ b/docs/guide/colorspace.rst
@@ -4,7 +4,7 @@ Colorspace
 Image types
 -----------
 
-Every :class:`~wand.image.Image` object has  :attr:`~wand.image.BaseImage.type`
+Every :class:`~wand.image.Image` object has :attr:`~wand.image.BaseImage.type`
 property which identifies its colorspace.  The value can be one of
 :const:`~wand.image.IMAGE_TYPES` enumeration, and set of its available
 values depends on its :attr:`~wand.image.Image.format` as well.  For example,

--- a/docs/guide/distortion.rst
+++ b/docs/guide/distortion.rst
@@ -36,7 +36,7 @@ Virtual Pixels
 ''''''''''''''
 
 When performing distortion on raster images, the resulting image often includes
-pixels that are outside original bounding raster. These regions are referred to
+pixels that are outside the original bounding raster. These regions are referred to
 as vertical pixels, and can be controlled by setting
 :attr:`Image.virtual_pixel <wand.image.BaseImage.virtual_pixel>` to any value
 defined in :const:`~wand.image.VIRTUAL_PIXEL_METHOD`.
@@ -425,7 +425,7 @@ preserve aspect ratios.
     Radius\ :sub:`max`, Radius\ :sub:`min`, Center\ :sub:`x`, Center\ :sub:`y`, Angle\ :sub:`start`, Angle\ :sub:`end`
 
 All the arguments are optional, and an argument of ``0`` will use the distance
-of the center to the closet edge as the default radius.
+of the center to the closest edge as the default radius.
 
 For example::
 

--- a/docs/guide/draw.rst
+++ b/docs/guide/draw.rst
@@ -42,7 +42,7 @@ An example::
         draw.stroke_color = Color('black')
         draw.stroke_width = 2
         draw.fill_color = Color('white')
-        draw.arc(( 25, 25),  # Stating point
+        draw.arc(( 25, 25),  # Starting point
                  ( 75, 75),  # Ending point
                  (135,-45))  # From bottom left around to top right
         with Image(width=100,
@@ -543,7 +543,7 @@ Both horizontal & vertical can be set independently with
     draw.rectangle(left=10, top=10, width=30, height=30, xradius=5, yradius=3)
     draw(image)
 
-Note that the stoke and the fill are determined by the following properties:
+Note that the stroke and the fill are determined by the following properties:
 
 - :attr:`~wand.drawing.Drawing.stroke_color`
 - :attr:`~wand.drawing.Drawing.stroke_dash_array`

--- a/docs/guide/effect.rst
+++ b/docs/guide/effect.rst
@@ -269,7 +269,7 @@ to reduce noise in an image, but also preserves edges.
 
 .. code-block:: python
 
-    from image.wand import Image
+    from wand.image import Image
 
     with Image(filename="hummingbird.jpg") as img:
         img.kuwahara(radius=2, sigma=1.5)
@@ -290,9 +290,9 @@ Shade
 
 .. versionadded:: 0.5.0
 
-Creates a 3D effect by simulating light from source where ``aziumth`` controls
+Creates a 3D effect by simulating light from source where ``azimuth`` controls
 the X/Y angle, and ``elevation`` controls the Z angle. You can also determine
-of the resulting image should be transformed to grayscale by passing ``gray``
+whether the resulting image should be transformed to grayscale by passing ``gray``
 boolean.
 
 .. code-block:: python

--- a/docs/guide/fx.rst
+++ b/docs/guide/fx.rst
@@ -241,7 +241,7 @@ Polaroid
 
 .. versionadded:: 0.5.4
 
-Wraps am image in a white board, and a slight shadow to create the special
+Wraps an image in a white board, and a slight shadow to create the special
 effect of a Polaroid print.
 
 .. code-block:: python
@@ -406,7 +406,7 @@ Tint
 .. versionadded:: 0.5.3
 
 Tint colorizes midtones of an image by blending the given ``color``.
-The ``alpha`` parameter controls how the blend is effected between color
+The ``alpha`` parameter controls how the blend is affected between color
 channels. However, this can be tricky to use, so when in doubt, use a
 ``alpha="gray(50)"`` argument.
 

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -94,7 +94,7 @@ MacPorts
 
       $ sudo port install imagemagick
 
-   If your Python in not installed using MacPorts, you have to export
+   If your Python is not installed using MacPorts, you have to export
    :envvar:`MAGICK_HOME` path as well.  Because Python that is not installed
    using MacPorts doesn't look up :file:`/opt/local`, the default path prefix
    of MacPorts packages.
@@ -146,7 +146,7 @@ libraries for C and C++` to make Wand able to link to it.
 Lastly you have to set :envvar:`MAGICK_HOME` environment variable to the path
 of ImageMagick (e.g. :file:`C:\\Program Files\\ImageMagick-6.9.3-Q16`).
 You can set it in :menuselection:`Computer --> Properties -->
-Advanced system settings --> Advanced --> Enviro&nment Variables...`.
+Advanced system settings --> Advanced --> Environment Variables...`.
 
 
 .. _explicit-link:

--- a/docs/guide/layers.rst
+++ b/docs/guide/layers.rst
@@ -99,7 +99,7 @@ Frame 6 size : (26, 27) page: (100, 100, 52, 52)
 
 .. image:: ../_images/layers-optmized-layers.png
 
-Notice each frame after the first has a reduce size & page x/y offset.
+Notice each frame after the first has a reduced size & page x/y offset.
 Contacting each frame shows only the minimum bounding region covering the pixel
 changes across each previous frame. *Note: the lime-green background is only
 there for a visual cue one the website, and has not special meaning outside of

--- a/docs/guide/morphology.rst
+++ b/docs/guide/morphology.rst
@@ -310,7 +310,7 @@ Smooth applies both `Open`_ & `Close`_ methods. This will remove small objects
 Edge In
 '''''''
 
-Edge In method performs a `Erode`_, but only keeps the targeted pixel next
+Edge In method performs an `Erode`_, but only keeps the targeted pixel next
 to a shape. This means the edge is drawn just inside the white of a object.
 
 .. code-block:: python

--- a/docs/guide/quantize.rst
+++ b/docs/guide/quantize.rst
@@ -86,7 +86,7 @@ Quantize
 
 .. versionadded:: 0.4.2
 
-Analyzes the colors in an image, and replace pixel values from a fixed number
+Analyzes the colors in an image, and replaces pixel values from a fixed number
 of color.
 
 .. code-block:: python

--- a/docs/guide/read.rst
+++ b/docs/guide/read.rst
@@ -41,7 +41,7 @@ The most frequently used way is just to open an image by its filename.
 
 .. _read-input-stream:
 
-Read a input stream
+Read an input stream
 -------------------
 
 If an image to open cannot be located by a filename but can be read through

--- a/docs/guide/transform.rst
+++ b/docs/guide/transform.rst
@@ -152,7 +152,7 @@ The type of statistic operation can be any of the following.
  - ``'root_mean_square'``
  - ``'standard_deviation'``
 
-The size neighboring pixels to evaluate can be defined by passing ``width``,
+The size of neighboring pixels to evaluate can be defined by passing ``width``,
 and ``height`` kwargs.
 
 .. code::

--- a/docs/guide/write.rst
+++ b/docs/guide/write.rst
@@ -60,7 +60,7 @@ method with the keyword argument ``filename``::
 
 .. note::
 
-    The image format does not effect the file being saved, to save with a given colorspace use::
+    The image format does not affect the file being saved, to save with a given colorspace use::
 
         from wand.image import Image
 
@@ -97,7 +97,7 @@ Want just a binary string of the image? Use
 
     from wand.image import Image
 
-    with image(filename='pikachu.png') as img:
+    with Image(filename='pikachu.png') as img:
         img.format = 'jpeg'
         jpeg_bin = img.make_blob()
 

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -34,7 +34,7 @@ There are some time-consuming tests.  You can skip these tests using
 
    $ pytest --skip-slow
 
-Be default, tests include regression testing for the PDF format. Test cases
+By default, tests include regression testing for the PDF format. Test cases
 will fail if the system does not include `Ghostscript`_ binaries. You can skip
 PDF dependent tests with ``--skip-pdf`` option:
 

--- a/docs/whatsnew/0.5.rst
+++ b/docs/whatsnew/0.5.rst
@@ -115,7 +115,7 @@ To understand the fundamental changes, please review
 
 .. _Porting to ImageMagick Version 7: https://www.imagemagick.org/script/porting.php
 
-Notes on Porting 6 t0 7
+Notes on Porting 6 to 7
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 A few key changes worth reviewing.
@@ -124,10 +124,10 @@ A few key changes worth reviewing.
 HDRI by Default
 '''''''''''''''
 Vanilla installs of ImageMagick-7 include HDRI enabled by default. Users may
-experiences increase depth of color, but with reduced performances during
+experience increased depth of color, but with reduced performance during
 certain color manipulation routines. Max color-values should never be
 hard-coded, but rely on :attr:`Image.quantum_range <wand.image.BaseImage.quantum_range>` to ensure
-consistent results. It is also possible to experiences color-value underflow /
+consistent results. It is also possible to experience color-value underflow /
 overflow during arithmetic operations when upgrading.
 
 An example of an underflow between versions::

--- a/docs/whatsnew/0.6.rst
+++ b/docs/whatsnew/0.6.rst
@@ -28,10 +28,10 @@ As expected, CMYK images will export 4 bytes for each color channel.
 ...     print(np.array(img).shape)
 (46, 70, 4)
 
-Numpy array's do not transport channel assignment by default, so users will be
+Numpy arrays do not transport channel assignment by default, so users will be
 responsible for passing this information back into a raster library.
 
->>> with Image.form_array(my_cmyk_array, channel_map="cmyk")  as img:
+>>> with Image.from_array(my_cmyk_array, channel_map="cmyk")  as img:
 ...     img.save(filename="output.tiff")
 
 Users expecting to keep RGBA array shapes should perform color space
@@ -56,7 +56,7 @@ of all the new methods.
 
  - :meth:`Image.auto_threshold() <wand.image.BaseImage.auto_threshold>` method.
  - :meth:`Image.canny() <wand.image.BaseImage.canny>` method.
- - :meth:`Image.clahe() <wand.image.BaseImage.canny>` method. Also known as "Contrast Limited Adaptive Histogram Equalization".
+ - :meth:`Image.clahe() <wand.image.BaseImage.clahe>` method. Also known as "Contrast Limited Adaptive Histogram Equalization".
  - :meth:`Image.color_threshold() <wand.image.BaseImage.color_threshold>` method.
  - :meth:`Image.complex() <wand.image.BaseImage.complex>` method.
  - :meth:`Image.connected_components() <wand.image.BaseImage.connected_components>` method.


### PR DESCRIPTION
Howdy! I noticed a typo in the documentation as I was reading it, so I fixed it. Then I had Claude scan for any other probable typos across all .rst files, and this is the resulting PR. (I didn't do this blindly; I've verified that each fix is legit.)

## Summary

Fixes typos across the documentation:

**guide/**
- **cli.rst**: "list" → "lists"
- **colorspace.rst**: remove double space
- **distortion.rst**: add missing "the"; "closet" → "closest"
- **draw.rst**: "Stating" → "Starting"; "stoke" → "stroke"
- **effect.rst**: `image.wand` → `wand.image`; "aziumth" → "azimuth"; "of" → "whether"
- **fx.rst**: "am" → "an"; "effected" → "affected"
- **install.rst**: "in not" → "is not"; "Enviro&nment" → "Environment"
- **layers.rst**: "reduce" → "reduced"
- **morphology.rst**: "a Erode" → "an Erode"
- **quantize.rst**: "replace" → "replaces"
- **read.rst**: "a input" → "an input"
- **transform.rst**: "The size neighboring" → "The size of neighboring"
- **write.rst**: "effect" → "affect"; `image` → `Image`

**docs/**
- **test.rst**: "Be default" → "By default"
- **whatsnew/0.5.rst**: "6 t0 7" → "6 to 7"; "experiences" → "experience" (×2); "performances" → "performance"
- **whatsnew/0.6.rst**: "array's" → "arrays"; "form_array" → "from_array"; wrong `clahe` cross-reference fixed