### PR TITLE
Change c_size_t to c_ulonglong for BaseImage.length_of_bytes() method…

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,9 @@ Unreleased.
    - ``'magickernelsharp2013'``
    - ``'magickernelsharp2021'``
 
+ - Fixed :meth:`Image.length_of_bytes() <wand.image.BaseImage.length_of_bytes>` method
+   by refactoring & applying :const:`c_magick_size_t <wand.cdefs.wandtypes.c_magick_size_t>`
+   type. [:issue:`686`]
  - [DOC] Fixed typos in documentation [:pull:`685` by Shawn Presser]
 
 

--- a/wand/cdefs/magick_image.py
+++ b/wand/cdefs/magick_image.py
@@ -6,7 +6,7 @@
 from ctypes import (CFUNCTYPE, POINTER, c_bool, c_char_p, c_double, c_int,
                     c_size_t, c_ubyte, c_void_p)
 
-from wand.cdefs.wandtypes import c_ssize_t
+from wand.cdefs.wandtypes import c_ssize_t, c_magick_size_t
 
 __all__ = ('MagickProgressMonitor', 'load')
 
@@ -545,7 +545,7 @@ def load(lib, IM_VERSION):
             c_void_p, POINTER(c_double), POINTER(c_double)
         ]
         lib.MagickGetImageKurtosis.restype = c_bool
-    lib.MagickGetImageLength.argtypes = [c_void_p, POINTER(c_size_t)]
+    lib.MagickGetImageLength.argtypes = [c_void_p, POINTER(c_magick_size_t)]
     lib.MagickGetImageLength.restype = c_bool
     if is_im_7:
         lib.MagickGetImageMask.argtypes = [c_void_p, c_int]

--- a/wand/cdefs/magick_property.py
+++ b/wand/cdefs/magick_property.py
@@ -4,9 +4,9 @@
 .. versionadded:: 0.5.0
 """
 from ctypes import (POINTER, c_bool, c_char_p, c_double, c_int, c_size_t,
-                    c_ubyte, c_uint, c_ulong, c_ulonglong, c_void_p)
+                    c_ubyte, c_uint, c_ulong, c_void_p)
 
-from wand.cdefs.wandtypes import c_ssize_t
+from wand.cdefs.wandtypes import c_ssize_t, c_magick_size_t
 
 __all__ = ('load',)
 
@@ -91,9 +91,9 @@ def load(lib, IM_VERSION):
     lib.MagickGetPointsize.restype = c_double
     lib.MagickGetQuantumRange.argtypes = [POINTER(c_size_t)]
     lib.MagickGetResource.argtypes = [c_int]
-    lib.MagickGetResource.restype = c_ulonglong
+    lib.MagickGetResource.restype = c_magick_size_t
     lib.MagickGetResourceLimit.argtypes = [c_int]
-    lib.MagickGetResourceLimit.restype = c_ulonglong
+    lib.MagickGetResourceLimit.restype = c_magick_size_t
     lib.MagickGetSamplingFactors.argtypes = [c_void_p, POINTER(c_size_t)]
     lib.MagickGetSamplingFactors.restype = POINTER(c_double)
     lib.MagickGetSize.argtypes = [c_void_p, POINTER(c_uint), POINTER(c_uint)]
@@ -172,7 +172,7 @@ def load(lib, IM_VERSION):
     lib.MagickSetPointsize.restype = c_bool
     lib.MagickSetResolution.argtypes = [c_void_p, c_double, c_double]
     lib.MagickSetResolution.restype = c_bool
-    lib.MagickSetResourceLimit.argtypes = [c_int, c_ulonglong]
+    lib.MagickSetResourceLimit.argtypes = [c_int, c_magick_size_t]
     lib.MagickSetResourceLimit.restype = c_bool
     lib.MagickSetSamplingFactors.argtypes = [
         c_void_p, c_size_t, POINTER(c_double)

--- a/wand/cdefs/wandtypes.py
+++ b/wand/cdefs/wandtypes.py
@@ -5,6 +5,7 @@
 """
 import ctypes
 import os
+import platform
 import sys
 
 __all__ = ('c_magick_real_t', 'c_magick_size_t', 'c_ssize_t')
@@ -34,11 +35,10 @@ else:
 del env_real
 
 
-# FIXME: Might need to rewrite to check against c_void_p size;
-# like `c_ssize_t` above, and not against window platform.
-if ctypes.sizeof(ctypes.c_size_t) == 8:
-    c_magick_size_t = ctypes.c_size_t
-elif ctypes.sizeof(ctypes.c_ulonglong) == 8:
-    c_magick_size_t = ctypes.c_ulonglong
+if platform.system() != 'Windows':
+    if ctypes.sizeof(ctypes.c_ulonglong) == 8:
+        c_magick_size_t = ctypes.c_ulonglong
+    else:
+        c_magick_size_t = ctypes.c_size_t
 else:
     c_magick_size_t = ctypes.c_uint64

--- a/wand/image.py
+++ b/wand/image.py
@@ -2067,7 +2067,7 @@ class BaseImage(Resource):
 
         .. versionadded:: 0.5.4
         """
-        size_ptr = ctypes.c_size_t(0)
+        size_ptr = ctypes.c_ulonglong(0)
         library.MagickGetImageLength(self.wand, ctypes.byref(size_ptr))
         return size_ptr.value
 

--- a/wand/image.py
+++ b/wand/image.py
@@ -22,6 +22,7 @@ from .api import libc, libmagick, library
 from .cdefs.structures import (AffineMatrix, CCObjectInfo, CCObjectInfo70A,
                                CCObjectInfo710, ChannelFeature, GeometryInfo,
                                PixelInfo, RectangleInfo)
+from .cdefs.wandtypes import c_magick_size_t
 from .color import Color
 from .compat import binary, encode_filename, text, to_bytes
 from .exceptions import (MissingDelegateError, WandException,
@@ -2067,7 +2068,7 @@ class BaseImage(Resource):
 
         .. versionadded:: 0.5.4
         """
-        size_ptr = ctypes.c_ulonglong(0)
+        size_ptr = c_magick_size_t(0)
         library.MagickGetImageLength(self.wand, ctypes.byref(size_ptr))
         return size_ptr.value
 

--- a/wand/resource.py
+++ b/wand/resource.py
@@ -12,6 +12,7 @@ import warnings
 from collections import abc
 
 from .api import library
+from .cdefs.wandtypes import c_magick_size_t
 from .exceptions import TYPE_MAP, WandException
 from .version import MAGICK_VERSION_NUMBER
 
@@ -356,8 +357,8 @@ class ResourceLimits(abc.MutableMapping):
         .. versionadded:: 0.5.1
         """
         genesis()
-        ull = ctypes.c_ulonglong(limit)
-        library.MagickSetResourceLimit(self._to_idx(resource), ull)
+        magick_size = c_magick_size_t(limit)
+        library.MagickSetResourceLimit(self._to_idx(resource), magick_size)
 
 
 #: (:class:`ResourceLimits`) Helper to get & set Magick Resource Limits.


### PR DESCRIPTION
Possible fix for #686. The C API's `MagickSizeType` may now be defined as `unsigned long long` rather than `size_t`.