### PR TITLE
Sync file offsets before reading or seeking

### DIFF
--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -122,6 +122,15 @@ def test_read_from_unicode_filename(fx_asset, tmp_path):
         assert img.width == 402
 
 
+def test_read_from_file_after_buffered_peek(fx_asset):
+    fpath = fx_asset.joinpath('mona-lisa.jpg')
+    with open(fpath, 'rb') as f:
+        f.read(16)
+        f.seek(0)
+        with Image(file=f) as img:
+            assert img.width == 402
+
+
 def test_read_with_colorspace(fx_asset):
     fpath = str(fx_asset.joinpath('cmyk.jpg'))
     with Image(filename=fpath,
@@ -278,6 +287,14 @@ def test_ping_from_blob(fx_asset):
 
 def test_ping_from_file(fx_asset):
     with fx_asset.joinpath('mona-lisa.jpg').open('rb') as fd:
+        with Image.ping(file=fd) as img:
+            assert img.size == (402, 599)
+
+
+def test_ping_from_file_after_buffered_peek(fx_asset):
+    with fx_asset.joinpath('mona-lisa.jpg').open('rb') as fd:
+        fd.read(16)
+        fd.seek(0)
         with Image.ping(file=fd) as img:
             assert img.size == (402, 599)
 

--- a/wand/image.py
+++ b/wand/image.py
@@ -13,6 +13,7 @@ error happened)::
 import ctypes
 import functools
 import numbers
+import os
 import weakref
 from collections import abc
 from io import IOBase
@@ -9879,6 +9880,12 @@ class Image(BaseImage):
                      callable(getattr(file, 'fileno', None)),
                      hasattr(file, 'mode'))
             if all(is_fd):
+                try:
+                    # Resync the fd offset before reading
+                    os.lseek(file.fileno(), file.tell(), os.SEEK_SET)
+                except (OSError, ValueError):
+                    # Do nothing if stream isn't seekable
+                    pass
                 fd = libc.fdopen(file.fileno(), binary(file.mode))
                 r = library.MagickPingImageFile(instance.wand, fd)
             elif not callable(getattr(file, 'read', None)):
@@ -10465,6 +10472,12 @@ class Image(BaseImage):
                      callable(getattr(file, 'fileno', None)),
                      hasattr(file, 'mode'))
             if all(is_fd):
+                try:
+                    # Resync the fd offset before reading
+                    os.lseek(file.fileno(), file.tell(), os.SEEK_SET)
+                except (OSError, ValueError):
+                    # Do nothing if stream isn't seekable
+                    pass
                 fd = libc.fdopen(file.fileno(), binary(file.mode))
                 r = library.MagickReadImageFile(self.wand, fd)
             elif not callable(getattr(file, 'read', None)):


### PR DESCRIPTION
This PR fixes #688 by forcing the OS cursor to match the object's logical position, so ImageMagick reads from the caller's intended position even when the file object's buffering has desynced the OS-level offset from its logical position.

I have also added two tests to verify that both `read()` and `ping()` work if the offsets are misaligned. Both tests fail before my fix and pass after my fix.